### PR TITLE
Modifying DPA shutdown anomaly pages

### DIFF
--- a/source/dea_seq_reset.rst
+++ b/source/dea_seq_reset.rst
@@ -23,10 +23,22 @@ Will it happen again?
 
 It appears likely that the anomaly will occur again.
 
+How is this Anomaly Diagnosed?
+------------------------------
+
+* The science run will be terminated, sending a ``scienceReport`` packet that will contain
+  non-zero ``fepErrorCodes`` and a non-zero ``terminationCode``.
+* Within a major frame (32.2 seconds), there will be a slight drop in DPA Input Current A and/or B,
+  (1DPICACU and/or 1DPICBCU) ~0.2-0.3 A. The drop in two input currents depends on which side is
+  running which FEPs.
+* Within a major frame, the 1STAT1ST bilevel will toggle off (science idle).
+* DEA Housekeeping will show sharp drops in the temperatures of FEP 0 and/or FEP 1, if they are
+  running.
+
 What is the first response?
 ---------------------------
 
-Most likely we will be notified by CXCDS Ops that data ceased prematurely for an 
+Most likely we will be notified by CXCDS Ops that data ceased prematurely for an
 observation. We need to:
  
 * Process the dump data and get access to the CXC products

--- a/source/dea_seq_reset.rst
+++ b/source/dea_seq_reset.rst
@@ -41,10 +41,10 @@ What is the first response?
 Most likely we will be notified by CXCDS Ops that data ceased prematurely for an
 observation. We need to:
  
-* Process the dump data and get access to the CXC products
-* Send an e-mail to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, 
+* Send an e-mail to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz,
   and Bev LaMarr)
-* Convene a telecon at the next reasonable moment. 
+* Process the dump data and get access to the CXC products
+* Convene a telecon at the next reasonable moment.
 * Examine data from the next observation because the setup for the next
   observation should clear the problem.
 

--- a/source/dea_shutdown.rst
+++ b/source/dea_shutdown.rst
@@ -28,9 +28,9 @@ Within a major frame (32.2 seconds), one should see:
 * 1DEPSA (DEA-A Power Supply On/Off) change from 1 to 0
 * All DEA-A Analog Voltages (1DEP3AVO, 1DEP2AVO, 1DEP1AVO, 1DEP0AVO, 1DEN0AVO, 1DEN1AVO) 
   go to 0.0 +/- 0.5 V 
-* 1DEICACU (DEA-A input current) drop to < 0.2 A (this value is noisy, so take an average)
+* 1DEICACU (DEA-A Input Current) drop to < 0.2 A (this value is noisy, so take an average)
 * DEA-A POWER should go to zero
-* 1DE28AVO (DEA-A +28V Input) is expected to have a small uptick, ~0.5 V, consistent with 
+* 1DE28AVO (DEA-A +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
 
 All other hardware telemetry should be nominal. The current values for these can be found 

--- a/source/dea_shutdown.rst
+++ b/source/dea_shutdown.rst
@@ -43,11 +43,11 @@ What is the first response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
  
-* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE* 
-  the shutdown. We want to know if a new occurrence looks just like the previous occurrences. 
-  If yes, it should appear as if in one frame the DEA-A turned off. 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr),
-* Convene a telecon at the next reasonable moment. A DEA-A recovery requires that the BEP be 
+* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
+  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
+  If yes, it should appear as if in one frame the DEA-A turned off.
+* Convene a telecon at the next reasonable moment. A DEA-A recovery requires that the BEP be
   warmbooted after the DEA-A is back on (see `the SOP <http://cxc.cfa.harvard.edu/acis/cmd_seq/deaa_on.pdf>`_ 
   and `Flight Note 572 <http://cxc.cfa.harvard.edu/acis/memos/Flight_Note572_DEA_Shutdown_Closeout_merged.pdf>`_
   for details).

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -47,11 +47,11 @@ What is the first response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE* 
-  the shutdown. We want to know if a new occurrence looks just like the previous occurrences. 
-  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Convene a telecon at the next reasonable moment. 
+* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
+  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
+  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+* Convene a telecon at the next reasonable moment.
 * DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
 * DPA-B shutdowns only require that the DPA-B be powered back on.

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -64,11 +64,11 @@ Impacts
 Relevant Procedures
 -------------------
 
-.. |dpaa_on| replace:: ``SOP_61038_DPAA_ON``
-.. _dpaa_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61038_DPAA_ON.pdf
+.. |dpaa_on| replace:: ``SOP_ACIS_DPAA_ON``
+.. _dpaa_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
 
-.. |dpab_on| replace:: ``SOP_61037_DPAB_ON``
-.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61037_DPAB_ON.pdf
+.. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
+.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -38,6 +38,7 @@ Within a major frame (32.2 seconds), one should see, for either DPA-A or DPA-B:
 * DPA-[AB] POWER should go to zero
 * 1DP28[AB]VO (DPA-[AB] +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
+* If DPA-A shuts down, the software and hardware bilevels will likely not have normal values.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
@@ -59,6 +60,9 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
 * Convene a telecon at the next reasonable moment.
+* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
+  Engineer to request it.
 * DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
 * DPA-B shutdowns only require that the DPA-B be powered back on.
@@ -67,6 +71,12 @@ Impacts
 -------
 
 * Until the DPA is powered back on, science operations will be interrupted.
+* In the case of a side A shutdown, the warmboot of the BEP will reset the parameters of the 
+  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
+  than expected input current) due to FEPs being off. This situation should resolve itself with 
+  the next observation.
+
 
 Relevant Procedures
 -------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -26,6 +26,23 @@ Will it happen again?
 
 It appears likely that the anomaly will occur again if the mission continues.
 
+
+How is this Anomaly Diagnosed?
+------------------------------
+
+Within a major frame (32.2 seconds), one should see, for either DPA-A or DPA-B:
+
+* 1DPPS[AB] (DPA-[AB] Power Supply On/Off) change from 1 to 0
+* 1DPP0[AB]V0 (DPA-[AB] +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPIC[AB]CU (DPA-[AB] Input Current) drop to < 0.2 A (this value is noisy, so take an average)
+* DPA-[AB] POWER should go to zero
+* 1DP28[AB]VO (DPA-[AB] +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
+  the load suddenly dropping to zero
+
+All other hardware telemetry should be nominal. The current values for these can be found
+on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
+engineering archive.
+
 What is the first response?
 ---------------------------
 

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -70,8 +70,10 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 Impacts
 -------
 
-* Until the DPA is powered back on, science operations will be interrupted.
-* In the case of a side A shutdown, the warmboot of the BEP will reset the parameters of the 
+* Until the DPA-A is powered back on, science operations will be interrupted, but this may not
+  be the case if DPA-B needs to be powered back on. In this case, science operations will need to
+  be stopped and the FEPs and video boards will need to be powered down.
+* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
   TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -16,6 +16,7 @@ The DPA-A has shut down 4 times over the mission:
 * October 26, 2000: 2000:300:15:40, obsid 979
 * December 19, 2002: 2002:353:20:26, obsid 60915
 * January 12, 2015: 2015:012:00:01, obsid 52186
+* December 9, 2016: 2016:344:07:40, obsid 17615
 
 and the DPA-B has shut down once:
 
@@ -48,6 +49,7 @@ What is the first response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
@@ -70,6 +72,9 @@ Relevant Procedures
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
 .. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
+.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
+.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
 
@@ -78,7 +83,7 @@ SOT Procedures
 
 * `Turn On DPA-A <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpaa_on.pdf>`_
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
-* `Load DEA Housekeeping Parameter Block and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/dea_hkp.pdf>`_
+* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
 * `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
 
 FOT Procedures
@@ -86,12 +91,14 @@ FOT Procedures
 
 * |dpaa_on|_
 * |dpab_on|_
+* |stdfoptg|_
 * |fptemp_121|_
 
 CAPs
 ++++
 
 * `CAP 1342 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1407 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -26,7 +26,6 @@ Will it happen again?
 
 It appears likely that the anomaly will occur again if the mission continues.
 
-
 How is this Anomaly Diagnosed?
 ------------------------------
 

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -50,6 +50,11 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
 * Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Call the Flight Directors:   
+
+  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
+  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
+
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -114,8 +114,10 @@ FOT Procedures
 CAPs
 ++++
 
-* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
 * `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
+* `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -112,8 +112,8 @@ FOT Procedures
 CAPs
 ++++
 
-* `CAP 1342 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
-* `CAP 1407 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -54,23 +54,20 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
-  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+  If yes, it should appear as if in one frame the DPA-A turned off.
 * Convene a telecon at the next reasonable moment.
-* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
+* DPA-A shutdowns also require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
-* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
-  to be stopped, and the FEPs and video boards maybe need to be powered down.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
-  needs to be powered back on science operations may need to be temporarily stopped.
-* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
-  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* Until the DPA-A is powered back on, science operations will be interrupted.
+* The warmboot of the BEP will reset the parameters of the TXINGS patch to their defaults. 
+  They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 
   the next observation.

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -59,8 +59,12 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns also require reloading the patches, restarting DEA housekeeping, and resetting 
-  the focal plane temperature. 
+* Prepare a CAP to power back on the DPA-A and bring it up for review. DPA-A shutdowns also 
+  require reloading the patches, restarting DEA housekeeping, and resetting the focal plane 
+  temperature. If *Chandra* is heading into the radiation belts, it may be necessary to also 
+  issue a ``WSVIDALLDN`` command to power off the video boards.
+* Execute the CAP at the next available comm. Reloading the flight software patches can take
+  a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.
 
 Impacts
 -------
@@ -71,7 +75,6 @@ Impacts
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 
   the next observation.
-
 
 Relevant Procedures
 -------------------
@@ -84,6 +87,12 @@ Relevant Procedures
 
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+.. |wsvidalldn| replace:: ``1A_WS007_164.CLD``
+.. _wsvidalldn: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_WS007_164.CLD
+
+.. |stdfoptgssc| replace:: ``I_ACIS_SW_STDFOPTG.ssc``
+.. _stdfoptgssc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/products/ssc/I_ACIS_SW_STDFOPTG.ssc
 
 SOT Procedures
 ++++++++++++++
@@ -98,6 +107,12 @@ FOT Procedures
 * |dpaa_on|_
 * |stdfoptg|_
 * |fptemp_121|_
+
+FOT Scripts
++++++++++++
+
+* |wsvidalldn|_
+* |stdfoptgssc|_
 
 CAPs
 ++++

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -1,12 +1,12 @@
-.. _dpa-shutdown:
+.. _dpaa-shutdown:
 
-DPA-A or DPA-B Anomalous Shutdown
-=================================
+DPA-A Anomalous Shutdown
+========================
 
 What is it?
 -----------
 
-The DPA-A or DPA-B shuts down anomalously, presumably due to a spurious command.
+The DPA-A shuts down anomalously, presumably due to a spurious command.
 
 When did it happen before?
 --------------------------
@@ -18,10 +18,6 @@ The DPA-A has shut down 4 times over the mission:
 * January 12, 2015: 2015:012:00:01, obsid 52186
 * December 9, 2016: 2016:344:07:40, obsid 17615
 
-and the DPA-B has shut down once:
-
-* December 13, 2007: 2007:347:17:50, obsid 58072
-
 Will it happen again?
 ---------------------
 
@@ -30,15 +26,15 @@ It appears likely that the anomaly will occur again if the mission continues.
 How is this Anomaly Diagnosed?
 ------------------------------
 
-Within a major frame (32.2 seconds), one should see, for either DPA-A or DPA-B:
+Within a major frame (32.2 seconds), one should see:
 
-* 1DPPS[AB] (DPA-[AB] Power Supply On/Off) change from 1 to 0
-* 1DPP0[AB]V0 (DPA-[AB] +5V Analog Voltage) drop to 0.0 +/- 0.3 V
-* 1DPIC[AB]CU (DPA-[AB] Input Current) drop to < 0.2 A (this value is noisy, so take an average)
-* DPA-[AB] POWER should go to zero
-* 1DP28[AB]VO (DPA-[AB] +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
+* 1DPPSA (DPA-A Power Supply On/Off) change from 1 to 0
+* 1DPP0AV0 (DPA-A +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPICACU (DPA-A Input Current) drop to < 0.2 A (this value is noisy, so take an average)
+* DPA-A POWER should go to zero
+* 1DP28AVO (DPA-A +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
-* If DPA-A shuts down, the software and hardware bilevels will likely not have normal values.
+* The software and hardware bilevels will likely not have normal values.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
@@ -65,14 +61,14 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   Engineer to request it.
 * DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
-* DPA-B shutdowns only require that the DPA-B be powered back on.
+* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
+  to be stopped, and the FEPs and video boards maybe need to be powered down.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but this may not
-  be the case if DPA-B needs to be powered back on. In this case, science operations will need to
-  be stopped and the FEPs and video boards will need to be powered down.
+* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
+  needs to be powered back on science operations may need to be temporarily stopped.
 * In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
   TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
@@ -86,9 +82,6 @@ Relevant Procedures
 .. |dpaa_on| replace:: ``SOP_ACIS_DPAA_ON``
 .. _dpaa_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
 
-.. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
-.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
-
 .. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
 .. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
 
@@ -99,7 +92,6 @@ SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-A <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpaa_on.pdf>`_
-* `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
 * `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
 * `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
 
@@ -107,7 +99,6 @@ FOT Procedures
 ++++++++++++++
 
 * |dpaa_on|_
-* |dpab_on|_
 * |stdfoptg|_
 * |fptemp_121|_
 
@@ -116,7 +107,6 @@ CAPs
 
 * `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 * `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
-* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
 * `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
 
 Relevant Notes/Memos

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -1,0 +1,110 @@
+.. _dpab-shutdown:
+
+DPA-B Anomalous Shutdown
+========================
+
+What is it?
+-----------
+
+The DPA-B shuts down anomalously, presumably due to a spurious command.
+
+When did it happen before?
+--------------------------
+
+The DPA-B has shut down once:  
+
+* December 13, 2007: 2007:347:17:50, obsid 58072
+
+Will it happen again?
+---------------------
+
+It appears likely that the anomaly will occur again if the mission continues.
+
+How is this Anomaly Diagnosed?
+------------------------------
+
+Within a major frame (32.2 seconds), one should see:
+
+* 1DPPSB (DPA-B Power Supply On/Off) change from 1 to 0
+* 1DPP0BV0 (DPA-B +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPICBCU (DPA-B Input Current) drop to < 0.2 A (this value is noisy, so take an average)
+* DPA-B POWER should go to zero
+* 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
+  the load suddenly dropping to zero
+
+All other hardware telemetry should be nominal. The current values for these can be found
+on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
+engineering archive.
+
+What is the first response?
+---------------------------
+
+Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
+
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Call the Flight Directors:   
+
+  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
+  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
+
+* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
+  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
+  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+* Convene a telecon at the next reasonable moment.
+* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
+  Engineer to request it.
+* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
+  the focal plane temperature. 
+* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
+  to be stopped, and the FEPs and video boards maybe need to be powered down.
+
+Impacts
+-------
+
+* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
+  needs to be powered back on science operations may need to be temporarily stopped.
+* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
+  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
+  than expected input current) due to FEPs being off. This situation should resolve itself with 
+  the next observation.
+
+
+Relevant Procedures
+-------------------
+
+.. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
+.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
+
+.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
+.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+
+.. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
+.. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+SOT Procedures
+++++++++++++++
+
+* `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
+* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
+* `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
+
+FOT Procedures
+++++++++++++++
+
+* |dpab_on|_
+* |stdfoptg|_
+* |fptemp_121|_
+
+CAPs
+++++
+
+* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
+
+Relevant Notes/Memos
+--------------------
+
+* `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
+* `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -49,28 +49,24 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
 
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
-  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
-  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+  the shutdown. We want to know if a new occurrence looks just like the single previous 
+  occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
 * Convene a telecon at the next reasonable moment.
-* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
-  the focal plane temperature. 
-* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
-  to be stopped, and the FEPs and video boards maybe need to be powered down.
+* Prepare a CAP to power back on the DPA-B and bring it up for review. If the shutdown occurs during 
+  an observation that utilitizes the side B FEPs, the active BEP may execut a watchdog reboot and
+  it may be necessary to warm boot the BEP. (**also standby mode?**)
+* Execute the CAP at the next available comm.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
-  needs to be powered back on science operations may need to be temporarily stopped.
-* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
-  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
-* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
-  than expected input current) due to FEPs being off. This situation should resolve itself with 
-  the next observation.
-
+* Until the DPA-B is powered back on, science operations which require the use of the side B FEPs
+  will be interrupted.
+* If it is necessary to warm boot the BEP, this will reset the parameters of the TXINGS patch 
+  to their defaults. They can be updated in the weekly load through a SAR.
 
 Relevant Procedures
 -------------------
@@ -78,33 +74,22 @@ Relevant Procedures
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
 .. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
-.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
-.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
-
-.. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
-.. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+.. |warmboot| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING``
+.. _warmboot: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
 
 SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
-* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
-* `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
+* `Warm Boot the Active ACIS BEP and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/warmboot_hkp.pdf>`_
 
 FOT Procedures
 ++++++++++++++
 
 * |dpab_on|_
-* |stdfoptg|_
-* |fptemp_121|_
+* |warmboot|_
 
 CAPs
 ++++
 
 * `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
-
-Relevant Notes/Memos
---------------------
-
-* `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
-* `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_

--- a/source/fep_reset.rst
+++ b/source/fep_reset.rst
@@ -83,10 +83,10 @@ What is the first response?
 Most likely we will be notified by CXCDS Ops that data from one or more of
 the CCDs stopped during an observation. We need to:
  
-* Process the dump data and get access to the CXC products
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, 
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz,
   and Bev LaMarr)
-* Convene a telecon at the next reasonable moment. 
+* Process the dump data and get access to the CXC products
+* Convene a telecon at the next reasonable moment.
 
 Impacts
 -------

--- a/source/hi_lo_anomaly.rst
+++ b/source/hi_lo_anomaly.rst
@@ -22,6 +22,17 @@ Will it happen again?
 
 It appears likely it could happen again.
 
+How is this Anomaly Diagnosed?
+------------------------------
+
+Both of the following symptoms will be noticed:
+
+* One or more FEPs will stop returning event data.
+* The ``deltaOverclock`` values reported from these FEPs are large and negative for the first three output nodes and
+  large and positive for the fourth output node.
+
+Both of these symptoms can be observed from one of the PMON pages.
+
 What is the first response?
 ---------------------------
 

--- a/source/hi_lo_anomaly.rst
+++ b/source/hi_lo_anomaly.rst
@@ -43,9 +43,9 @@ written to intervene if the observation with the anomaly is still in progress to
 
 If not, we need to: 
 
-* Process the dump data and get access to the CXC products 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Convene a telecon at the next reasonable moment. 
+* Process the dump data and get access to the CXC products
+* Convene a telecon at the next reasonable moment.
 * Examine data from the next observation, because the setup for the next observation should 
   clear the problem.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -16,7 +16,8 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
-   dpa_shutdown
+   dpaa_shutdown
+   dpab_shutdown
    dea_shutdown
    dea_seq_reset
    fep_reset


### PR DESCRIPTION
This PR modifies the DPA shutdown page, firstly by splitting it into two, one for DPA-A and another for DPA-B. 

The rest of the edits are comprised of adding procedures and scripts that may or may not be used in such an event, and adding in extra steps that need to be taken in response. 

These edits were prompted by the anomalous DPA-A shutdown of 2016:344. 