### PR TITLE
Modifying DPA shutdown pages

### DIFF
--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -38,6 +38,7 @@ Within a major frame (32.2 seconds), one should see, for either DPA-A or DPA-B:
 * DPA-[AB] POWER should go to zero
 * 1DP28[AB]VO (DPA-[AB] +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
+* If DPA-A shuts down, the software and hardware bilevels will likely not have normal values.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
@@ -59,6 +60,9 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
 * Convene a telecon at the next reasonable moment.
+* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
+  Engineer to request it.
 * DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
 * DPA-B shutdowns only require that the DPA-B be powered back on.
@@ -67,6 +71,12 @@ Impacts
 -------
 
 * Until the DPA is powered back on, science operations will be interrupted.
+* In the case of a side A shutdown, the warmboot of the BEP will reset the parameters of the 
+  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
+  than expected input current) due to FEPs being off. This situation should resolve itself with 
+  the next observation.
+
 
 Relevant Procedures
 -------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -70,8 +70,10 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 Impacts
 -------
 
-* Until the DPA is powered back on, science operations will be interrupted.
-* In the case of a side A shutdown, the warmboot of the BEP will reset the parameters of the 
+* Until the DPA-A is powered back on, science operations will be interrupted, but this may not
+  be the case if DPA-B needs to be powered back on. In this case, science operations will need to
+  be stopped and the FEPs and video boards will need to be powered down.
+* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
   TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -16,6 +16,7 @@ The DPA-A has shut down 4 times over the mission:
 * October 26, 2000: 2000:300:15:40, obsid 979
 * December 19, 2002: 2002:353:20:26, obsid 60915
 * January 12, 2015: 2015:012:00:01, obsid 52186
+* December 9, 2016: 2016:344:07:40, obsid 17615
 
 and the DPA-B has shut down once:
 
@@ -48,6 +49,7 @@ What is the first response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
@@ -70,6 +72,9 @@ Relevant Procedures
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
 .. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
+.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
+.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
 
@@ -78,7 +83,7 @@ SOT Procedures
 
 * `Turn On DPA-A <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpaa_on.pdf>`_
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
-* `Load DEA Housekeeping Parameter Block and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/dea_hkp.pdf>`_
+* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
 * `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
 
 FOT Procedures
@@ -86,12 +91,14 @@ FOT Procedures
 
 * |dpaa_on|_
 * |dpab_on|_
+* |stdfoptg|_
 * |fptemp_121|_
 
 CAPs
 ++++
 
 * `CAP 1342 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1407 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -50,6 +50,11 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
 * Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Call the Flight Directors:   
+
+  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
+  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
+
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -114,8 +114,10 @@ FOT Procedures
 CAPs
 ++++
 
-* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
 * `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
+* `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpa_shutdown.rst
+++ b/source/dpa_shutdown.rst
@@ -112,8 +112,8 @@ FOT Procedures
 CAPs
 ++++
 
-* `CAP 1342 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
-* `CAP 1407 (DPA-A Poweroff Recovery) <http://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -60,12 +60,11 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Prepare a CAP and submit it for review. This CAP will have the following steps:
 
-  - Power on the DPA side A
-  - Reloading the patches
-  - Restarting DEA housekeeping
-  - Resetting the focal plane temperature to -121 :math:`^\circ{\rm C}`. 
+  - Power on the DPA side A (|dpaa_on|_)
+  - Reload the patches and restart DEA housekeeping (|stdfoptg|_)
+  - Reset the focal plane temperature to -121 :math:`^\circ{\rm C}` (|fptemp_121|_)
   - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN`` 
-    command to power off the video boards.
+    command to power off the video boards (|wsvidalldn|_)
 
 * Execute the CAP at the next available comm. Reloading the flight software patches can take
   a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -23,7 +23,7 @@ Will it happen again?
 
 It appears likely that the anomaly will occur again if the mission continues.
 
-How is this Anomaly Diagnosed?
+How is this anomaly diagnosed?
 ------------------------------
 
 Within a major frame (32.2 seconds), one should see:
@@ -40,23 +40,23 @@ All other hardware telemetry should be nominal. The current values for these can
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
 engineering archive.
 
-What is the first response?
----------------------------
+What is the response?
+---------------------
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and that the ACIS team is
-  investigating.
-* Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
+* Send an email to ``sot_red_alert`` explaining the status of ACIS and state that the ACIS team
+  is investigating.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
   email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A turned off.
 * Once analysis of the dump data is complete, convene a telecon at the next reasonable moment
-  with the ACIS team and Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr, and review the
-  diagnosis. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
+  with the ACIS team and review the diagnosis. The MIT ACIS team (Peter Ford, Bob Goeke, Mark
+  Bautz, and Bev LaMarr) should also be included in the discussion, either in the telecon or
+  via email. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
   recovery. If the diagnosis is not consistentwith previous DPA-A anomalies, stop and start a
   more involved analysis with the ACIS team.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -29,7 +29,7 @@ How is this anomaly diagnosed?
 Within a major frame (32.2 seconds), one should see:
 
 * 1DPPSA (DPA-A Power Supply On/Off) change from 1 to 0 (On to Off)
-* 1DPP0AV0 (DPA-A +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPP0AVO (DPA-A +5V Analog Voltage) drop to 0.0 +/- 0.3 V
 * 1DPICACU (DPA-A Input Current) drop to < 0.2 A (this value is noisy, so take an average)
 * DPA-A POWER should go to zero
 * 1DP28AVO (DPA-A +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
@@ -46,8 +46,8 @@ What is the response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_red_alert`` explaining the status of ACIS and state that the ACIS team
-  is investigating.
+* Send an email to ``sot_red_alert`` announcing a telecon to brief the FOT, SOT, and FDs on
+  the diagnosis and the plan to develop a CAP to recover.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
   email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
@@ -63,7 +63,9 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
   a CAP to recover.
-* Prepare a CAP and submit it for review. This CAP will have the following steps:
+* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu. It will also
+  be necessary to call the OC/CC to determine which number should be used for the CAP. This CAP
+  will have the following steps:
 
   - Power on the DPA side A (|dpaa_on|_)
   - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN``

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -59,7 +59,7 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* Prepare a CAP to power back on the DPA-A and bring it up for review. DPA-A shutdowns also 
+* Prepare a CAP to power back on the DPA-A and submit it for review. DPA-A shutdowns also 
   require reloading the patches, restarting DEA housekeeping, and resetting the focal plane 
   temperature. If *Chandra* is heading into the radiation belts, it may be necessary to also 
   issue a ``WSVIDALLDN`` command to power off the video boards.
@@ -80,13 +80,13 @@ Relevant Procedures
 -------------------
 
 .. |dpaa_on| replace:: ``SOP_ACIS_DPAA_ON``
-.. _dpaa_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
+.. _dpaa_on: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
 
 .. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
-.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+.. _stdfoptg: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
 
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
-.. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+.. _fptemp_121: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
 
 .. |wsvidalldn| replace:: ``1A_WS007_164.CLD``
 .. _wsvidalldn: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_WS007_164.CLD

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -130,3 +130,4 @@ Relevant Notes/Memos
 
 * `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
 * `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_
+* `Flight Note 563 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note563_DPA-A_Turn_Off_Anomaly_Report.pdf>`_

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -110,8 +110,12 @@ FOT Procedures
 FOT Scripts
 +++++++++++
 
-* |wsvidalldn|_
 * |stdfoptgssc|_
+
+CLD Scripts
++++++++++++
+
+* |wsvidalldn|_
 
 CAPs
 ++++

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -45,11 +45,12 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_red_alert`` announcing a telecon to brief the FOT, SOT, and FDs on
-  the diagnosis and the plan to develop a CAP to recover.
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr). If
+  it is off-hours, call Peter and Bob.
+* Send an email to ``sot_red_alert`` announcing that the ACIS team is aware of the DPA-A shutdown
+  and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
-  email or call when the dump file is available.
+  email or call us when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A turned off.
@@ -57,15 +58,15 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   with the ACIS team and review the diagnosis. The MIT ACIS team (Peter Ford, Bob Goeke, Mark
   Bautz, and Bev LaMarr) should also be included in the discussion, either in the telecon or
   via email. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
-  recovery. If the diagnosis is not consistentwith previous DPA-A anomalies, stop and start a
+  recovery. If the diagnosis is not consistent with previous DPA-A anomalies, stop and start a
   more involved analysis with the ACIS team.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
-* Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
-  a CAP to recover.
-* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu. It will also
-  be necessary to call the OC/CC to determine which number should be used for the CAP. This CAP
-  will have the following steps:
+* Send an email to ``sot_red_alert`` and call a telecon with the FOT, SOT, and FDs to brief
+  them on the diagnosis and the plan to develop a CAP to recover.
+* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu, and cc: acisdude.
+  It will also be necessary to call the OC/CC to determine which number should be used for the CAP.
+  This CAP will have the following steps:
 
   - Power on the DPA side A (|dpaa_on|_)
   - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN``

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -54,23 +54,20 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
-  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+  If yes, it should appear as if in one frame the DPA-A turned off.
 * Convene a telecon at the next reasonable moment.
-* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
+* DPA-A shutdowns also require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
-* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
-  to be stopped, and the FEPs and video boards maybe need to be powered down.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
-  needs to be powered back on science operations may need to be temporarily stopped.
-* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
-  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* Until the DPA-A is powered back on, science operations will be interrupted.
+* The warmboot of the BEP will reset the parameters of the TXINGS patch to their defaults. 
+  They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 
   the next observation.

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -59,8 +59,12 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns also require reloading the patches, restarting DEA housekeeping, and resetting 
-  the focal plane temperature. 
+* Prepare a CAP to power back on the DPA-A and bring it up for review. DPA-A shutdowns also 
+  require reloading the patches, restarting DEA housekeeping, and resetting the focal plane 
+  temperature. If *Chandra* is heading into the radiation belts, it may be necessary to also 
+  issue a ``WSVIDALLDN`` command to power off the video boards.
+* Execute the CAP at the next available comm. Reloading the flight software patches can take
+  a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.
 
 Impacts
 -------
@@ -71,7 +75,6 @@ Impacts
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
   than expected input current) due to FEPs being off. This situation should resolve itself with 
   the next observation.
-
 
 Relevant Procedures
 -------------------
@@ -84,6 +87,12 @@ Relevant Procedures
 
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+.. |wsvidalldn| replace:: ``1A_WS007_164.CLD``
+.. _wsvidalldn: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_WS007_164.CLD
+
+.. |stdfoptgssc| replace:: ``I_ACIS_SW_STDFOPTG.ssc``
+.. _stdfoptgssc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/products/ssc/I_ACIS_SW_STDFOPTG.ssc
 
 SOT Procedures
 ++++++++++++++
@@ -98,6 +107,12 @@ FOT Procedures
 * |dpaa_on|_
 * |stdfoptg|_
 * |fptemp_121|_
+
+FOT Scripts
++++++++++++
+
+* |wsvidalldn|_
+* |stdfoptgssc|_
 
 CAPs
 ++++

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -50,8 +50,8 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr). If
-  it is off-hours, call Peter and Bob.
+* Send an email to the ACIS team at the official anomaly email address. If it is off-hours, call
+  Peter and Bob.
 * Send an email to ``sot_red_alert`` announcing that the ACIS team is aware of the DPA-A shutdown
   and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -46,14 +46,23 @@ What is the first response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and that the ACIS team is
+  investigating.
 * Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
+* Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
+  email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A turned off.
-* Convene a telecon at the next reasonable moment.
+* Once analysis of the dump data is complete, convene a telecon at the next reasonable moment
+  with the ACIS team and Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr, and review the
+  diagnosis. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
+  recovery. If the diagnosis is not consistentwith previous DPA-A anomalies, stop and start a
+  more involved analysis with the ACIS team.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
+* Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
+  a CAP to recover.
 * Prepare a CAP and submit it for review. This CAP will have the following steps:
 
   - Power on the DPA side A (|dpaa_on|_)
@@ -64,6 +73,8 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Execute the CAP at the next available comm. Reloading the flight software patches can take
   a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.
+* Write a shift report and distribute to ``sot_shift`` to inform the project that ACIS is restored
+  to its default configuration.
 
 Impacts
 -------

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -116,13 +116,13 @@ FOT Scripts
 CAPs
 ++++
 
-* `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
+* `CAP 1407 (DPA-A Poweroff Recovery) <http://cxc.cfa.harvard.edu/acis/CAPs/CAP1407_dpaa_poweroff_recovery.pdf>`_
 * `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
 * `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
 
 Relevant Notes/Memos
 --------------------
 
-* `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
-* `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_
+* `Flight Note 394 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note394_DPA_Turn_Off_Anomaly.pdf>`_
+* `Flight Note 417 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note417_DPA_Turn_Off_Anomaly.pdf>`_
 * `Flight Note 563 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note563_DPA-A_Turn_Off_Anomaly_Report.pdf>`_

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -57,12 +57,16 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   If yes, it should appear as if in one frame the DPA-A turned off.
 * Convene a telecon at the next reasonable moment.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
-* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
-  Engineer to request it.
+* Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Prepare a CAP to power back on the DPA-A and submit it for review. DPA-A shutdowns also 
-  require reloading the patches, restarting DEA housekeeping, and resetting the focal plane 
-  temperature. If *Chandra* is heading into the radiation belts, it may be necessary to also 
-  issue a ``WSVIDALLDN`` command to power off the video boards.
+  require:
+
+  - Reloading the patches
+  - Restarting DEA housekeeping
+  - Resetting the focal plane temperature to -121 :math:`^\circ{\rm C}`. 
+  - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN`` 
+    command to power off the video boards.
+
 * Execute the CAP at the next available comm. Reloading the flight software patches can take
   a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.
 

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -84,6 +84,11 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Write a shift report and distribute to ``sot_shift`` to inform the project that ACIS is restored
   to its default configuration.
 
+.. note::
+
+   As of this writing, the latest ACIS Flight Software Patch is F, Optional Patch G. Before preparing
+   the CAP, the latest version of the procedure should be checked.
+
 Impacts
 -------
 

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -61,10 +61,10 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Prepare a CAP and submit it for review. This CAP will have the following steps:
 
   - Power on the DPA side A (|dpaa_on|_)
+  - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN``
+    command to power off the video boards (|wsvidalldn|_)
   - Reload the patches and restart DEA housekeeping (|stdfoptg|_)
   - Reset the focal plane temperature to -121 :math:`^\circ{\rm C}` (|fptemp_121|_)
-  - If *Chandra* is heading into the radiation belts, it may be necessary to also issue a ``WSVIDALLDN`` 
-    command to power off the video boards (|wsvidalldn|_)
 
 * Execute the CAP at the next available comm. Reloading the flight software patches can take
   a half an hour, so ensure that there is enough time in the comm to execute the entire procedure.

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -28,7 +28,7 @@ How is this Anomaly Diagnosed?
 
 Within a major frame (32.2 seconds), one should see:
 
-* 1DPPSA (DPA-A Power Supply On/Off) change from 1 to 0
+* 1DPPSA (DPA-A Power Supply On/Off) change from 1 to 0 (On to Off)
 * 1DPP0AV0 (DPA-A +5V Analog Voltage) drop to 0.0 +/- 0.3 V
 * 1DPICACU (DPA-A Input Current) drop to < 0.2 A (this value is noisy, so take an average)
 * DPA-A POWER should go to zero

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -8,6 +8,11 @@ What is it?
 
 The DPA-A shuts down anomalously, presumably due to a spurious command.
 
+.. note::
+
+    The diagnosis and response to this anomaly presented in this document assumes that the
+    active BEP is powered by DPA side A.
+
 When did it happen before?
 --------------------------
 
@@ -34,7 +39,7 @@ Within a major frame (32.2 seconds), one should see:
 * DPA-A POWER should go to zero
 * 1DP28AVO (DPA-A +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
-* The software and hardware bilevels will likely not have normal values.
+* The software and hardware bilevels will likely not have normal values if BEP side A is active.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -95,11 +95,29 @@ Relevant Procedures
 .. |dpaa_on| replace:: ``SOP_ACIS_DPAA_ON``
 .. _dpaa_on: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
 
+.. |dpaa_on_pdf| replace:: PDF
+.. _dpaa_on_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
+
+.. |dpaa_on_doc| replace:: DOC
+.. _dpaa_on_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.doc
+
 .. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
 .. _stdfoptg: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
 
+.. |stdfoptg_pdf| replace:: PDF
+.. _stdfoptg_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+
+.. |stdfoptg_doc| replace:: DOC
+.. _stdfoptg_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.doc
+
 .. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
 .. _fptemp_121: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+.. |fptemp_121_pdf| replace:: PDF
+.. _fptemp_121_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+.. |fptemp_121_doc| replace:: DOC
+.. _fptemp_121_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
 
 .. |wsvidalldn| replace:: ``1A_WS007_164.CLD``
 .. _wsvidalldn: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_WS007_164.CLD
@@ -117,9 +135,9 @@ SOT Procedures
 FOT Procedures
 ++++++++++++++
 
-* |dpaa_on|_
-* |stdfoptg|_
-* |fptemp_121|_
+* ``SOP_ACIS_DPAA_ON`` (|dpaa_on_pdf|_) (|dpaa_on_doc|_)
+* ``SOP_ACIS_SW_STDFOPTG`` (|stdfoptg_pdf|_) (|stdfoptg_doc|_)
+* ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C`` (|fptemp_121_pdf|_) (|fptemp_121_doc|_)
 
 FOT Scripts
 +++++++++++
@@ -134,9 +152,24 @@ CLD Scripts
 CAPs
 ++++
 
-* `CAP 1407 (DPA-A Poweroff Recovery) <http://cxc.cfa.harvard.edu/acis/CAPs/CAP1407_dpaa_poweroff_recovery.pdf>`_
-* `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
-* `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
+.. |cap818_pdf| replace:: PDF
+.. _cap818_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf
+
+.. |cap1342_pdf| replace:: PDF
+.. _cap1342_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf
+
+.. |cap1342_doc| replace:: DOC
+.. _cap1342_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.doc
+
+.. |cap1407_pdf| replace:: PDF
+.. _cap1407_pdf: http://cxc.cfa.harvard.edu/acis/CAPs/CAP1407_dpaa_poweroff_recovery.pdf
+
+.. |cap1407_doc| replace:: DOC
+.. _cap1407_doc: http://cxc.cfa.harvard.edu/acis/CAPs/CAP1407_dpaa_poweroff_recovery.doc
+
+* CAP 1407 (DPA-A Poweroff Recovery) (|cap1407_pdf|_) (|cap1407_doc|_)
+* CAP 1342 (DPA-A Poweroff Recovery) (|cap1342_pdf|_) (|cap1342_doc|_)
+* CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) (|cap818_pdf|_)
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -1,12 +1,12 @@
-.. _dpa-shutdown:
+.. _dpaa-shutdown:
 
-DPA-A or DPA-B Anomalous Shutdown
-=================================
+DPA-A Anomalous Shutdown
+========================
 
 What is it?
 -----------
 
-The DPA-A or DPA-B shuts down anomalously, presumably due to a spurious command.
+The DPA-A shuts down anomalously, presumably due to a spurious command.
 
 When did it happen before?
 --------------------------
@@ -18,10 +18,6 @@ The DPA-A has shut down 4 times over the mission:
 * January 12, 2015: 2015:012:00:01, obsid 52186
 * December 9, 2016: 2016:344:07:40, obsid 17615
 
-and the DPA-B has shut down once:
-
-* December 13, 2007: 2007:347:17:50, obsid 58072
-
 Will it happen again?
 ---------------------
 
@@ -30,15 +26,15 @@ It appears likely that the anomaly will occur again if the mission continues.
 How is this Anomaly Diagnosed?
 ------------------------------
 
-Within a major frame (32.2 seconds), one should see, for either DPA-A or DPA-B:
+Within a major frame (32.2 seconds), one should see:
 
-* 1DPPS[AB] (DPA-[AB] Power Supply On/Off) change from 1 to 0
-* 1DPP0[AB]V0 (DPA-[AB] +5V Analog Voltage) drop to 0.0 +/- 0.3 V
-* 1DPIC[AB]CU (DPA-[AB] Input Current) drop to < 0.2 A (this value is noisy, so take an average)
-* DPA-[AB] POWER should go to zero
-* 1DP28[AB]VO (DPA-[AB] +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
+* 1DPPSA (DPA-A Power Supply On/Off) change from 1 to 0
+* 1DPP0AV0 (DPA-A +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPICACU (DPA-A Input Current) drop to < 0.2 A (this value is noisy, so take an average)
+* DPA-A POWER should go to zero
+* 1DP28AVO (DPA-A +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
-* If DPA-A shuts down, the software and hardware bilevels will likely not have normal values.
+* The software and hardware bilevels will likely not have normal values.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
@@ -65,14 +61,14 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   Engineer to request it.
 * DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
   the focal plane temperature. 
-* DPA-B shutdowns only require that the DPA-B be powered back on.
+* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
+  to be stopped, and the FEPs and video boards maybe need to be powered down.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but this may not
-  be the case if DPA-B needs to be powered back on. In this case, science operations will need to
-  be stopped and the FEPs and video boards will need to be powered down.
+* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
+  needs to be powered back on science operations may need to be temporarily stopped.
 * In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
   TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
 * After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
@@ -86,9 +82,6 @@ Relevant Procedures
 .. |dpaa_on| replace:: ``SOP_ACIS_DPAA_ON``
 .. _dpaa_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAA_ON.pdf
 
-.. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
-.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
-
 .. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
 .. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
 
@@ -99,7 +92,6 @@ SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-A <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpaa_on.pdf>`_
-* `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
 * `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
 * `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
 
@@ -107,7 +99,6 @@ FOT Procedures
 ++++++++++++++
 
 * |dpaa_on|_
-* |dpab_on|_
 * |stdfoptg|_
 * |fptemp_121|_
 
@@ -116,7 +107,6 @@ CAPs
 
 * `CAP 1407 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1407_dpaa_poweroff_recovery/CAP_1407_dpaa_poweroff_recovery.pdf>`_
 * `CAP 1342 (DPA-A Poweroff Recovery) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1342_dpaa_poweroff_recovery/CAP_1342_dpaa_poweroff_recovery.pdf>`_
-* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
 * `CAP 818 (DPA-A Side Recovery from Enabled/Powered Off State) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/0801_0900/CAP_0818_DPA-A%20Power%20Off%20Recovery/CAP_818_2002_354_not_signed.pdf>`_
 
 Relevant Notes/Memos

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -58,9 +58,9 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Convene a telecon at the next reasonable moment.
 * As soon as the time of the shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
-* Prepare a CAP to power back on the DPA-A and submit it for review. DPA-A shutdowns also 
-  require:
+* Prepare a CAP and submit it for review. This CAP will have the following steps:
 
+  - Power on the DPA side A
   - Reloading the patches
   - Restarting DEA housekeeping
   - Resetting the focal plane temperature to -121 :math:`^\circ{\rm C}`. 

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -47,11 +47,7 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
 * Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
-* Call the Flight Directors:   
-
-  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
-  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
-
+* Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
   If yes, it should appear as if in one frame the DPA-A turned off.

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -31,6 +31,7 @@ Within a major frame (32.2 seconds), one should see:
 * DPA-B POWER should go to zero
 * 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
+* If the DPA-B shutdown causes a watchdog reboot of the BEP, then 1STAT2ST = 0. 
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
@@ -55,9 +56,10 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* Prepare a CAP to power back on the DPA-B and bring it up for review. If the shutdown occurs during 
-  an observation that utilitizes the side B FEPs, the active BEP may execut a watchdog reboot and
-  it may be necessary to warm boot the BEP. (**also standby mode?**)
+* Prepare a CAP to power back on the DPA-B and submit it for review. This CAP should also put ACIS
+  into "thermal standby mode" before executing. If the shutdown occurs during an observation that 
+  utilitizes the side B FEPs, the active BEP may execut a watchdog reboot and it may be necessary 
+  to warm boot the BEP. 
 * Execute the CAP at the next available comm.
 
 Impacts
@@ -72,21 +74,26 @@ Relevant Procedures
 -------------------
 
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
-.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
+.. _dpab_on: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
 .. |warmboot| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING``
-.. _warmboot: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+.. _warmboot: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+
+.. |standby| replace:: ``SOP_61021_STANDBY``
+.. _standby: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61021_STANDBY.pdf
 
 SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
+* `Put ACIS Into Thermal Standby Mode <http://cxc.cfa.harvard.edu/acis/cmd_seq/standby.ps>`_
 * `Warm Boot the Active ACIS BEP and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/warmboot_hkp.pdf>`_
 
 FOT Procedures
 ++++++++++++++
 
 * |dpab_on|_
+* |standby|_
 * |warmboot|_
 
 CAPs

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -47,11 +47,7 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
 * Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
-* Call the Flight Directors:   
-
-  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
-  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
-
+* Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the single previous 
   occurrence. If yes, it should appear as if in one frame the DPA-B turned off.

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -58,10 +58,25 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Convene a telecon at the next reasonable moment.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
-* Prepare a CAP to power back on the DPA-B and submit it for review. This CAP should also put ACIS
-  into "thermal standby mode" before executing. If the shutdown occurs during an observation that 
-  utilitizes the side B FEPs, or if a subsequent observation requests them, the active BEP may 
-  execute a watchdog reboot and it may be necessary to warm boot the BEP. 
+* Prepare a CAP and submit it for review. The steps in the CAP will depend on whether or not the
+  active BEP has executed a watchdog reboot. This may happen if the shutdown occurs during an
+  observation that utilitizes the side B FEPs, or if a subsequent observation requests them.
+
+  1. If the BEP has not executed a watchdog reboot, the steps should be:
+
+     - Turn on DPA side B (|dpab_on|_)
+
+  2. If the BEP has executed a watchdog reboot, the steps should be:
+
+     - Stop the science run and power down the FEPs and video boards (|standby|_)
+     - Turn on DPA side B (|dpab_on|_)
+     - Warm-boot the BEP and start a DEA housekeeping run (|warmboot|_).
+
+  At this point in the mission (Jan 2017), it is standard practice to power off unused FEPs to
+  reduce power consumption and keep the electronics temperatures lower. For this reason, it is
+  believed that it is safe to power on the DPA side B during a science run that does not use
+  these FEPs. If this practice is changed later in the mission, this procedure may have to be
+  revisited.
 * Execute the CAP at the next available comm.
 
 Impacts

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -20,7 +20,7 @@ Will it happen again?
 
 It appears likely that the anomaly will occur again if the mission continues.
 
-How is this Anomaly Diagnosed?
+How is this anomaly diagnosed?
 ------------------------------
 
 Within a major frame (32.2 seconds), one should see:
@@ -40,24 +40,24 @@ All other hardware telemetry should be nominal. The current values for these can
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
 engineering archive.
 
-What is the first response?
----------------------------
+What is the response?
+---------------------
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and that the ACIS team is
-  investigating.
-* Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
+* Send an email to ``sot_red_alert`` explaining the status of ACIS and state that the ACIS team
+  is investigating.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
   email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the single previous 
   occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
 * Once analysis of the dump data is complete, convene a telecon at the next reasonable moment
-  with the ACIS team and Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr, and review the
-  diagnosis. If the diagnosis is consistent with previous DPA-B anomalies, proceed with the
-  recovery. If the diagnosis is not consistentwith previous DPA-B anomalies, stop and start a
+  with the ACIS team and review the diagnosis. The MIT ACIS team (Peter Ford, Bob Goeke, Mark
+  Bautz, and Bev LaMarr) should also be included in the discussion, either in the telecon or
+  via email. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
+  recovery. If the diagnosis is not consistentwith previous DPA-A anomalies, stop and start a
   more involved analysis with the ACIS team.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -37,9 +37,7 @@ Within a major frame (32.2 seconds), one should see:
 * 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
 * If 1STAT2ST = 0, the DPA-B shutdown has caused a watchdog reboot of the BEP in use. This will
-  happen if the DPA-B shuts down during an observation which is using B-side FEPs, or if the DPA-B
-  shuts down during an observation which is not using B-side FEPs but a subsequent observation does
-  use them.
+  happen if the DPA-B shuts down during an observation which is using B-side FEPs.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -8,6 +8,11 @@ What is it?
 
 The DPA-B shuts down anomalously, presumably due to a spurious command.
 
+.. note::
+
+    The diagnosis and response to this anomaly presented in this document assumes that the
+    active BEP is powered by DPA side A.
+
 When did it happen before?
 --------------------------
 
@@ -99,7 +104,7 @@ Impacts
 -------
 
 * Until the DPA-B is powered back on, science operations which require the use of the side B FEPs
-  will be interrupted.
+  will be affected.
 * If it is necessary to warm boot the BEP, this will reset the parameters of the TXINGS patch 
   to their defaults. They can be updated in the weekly load through a SAR.
 

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -109,11 +109,32 @@ Relevant Procedures
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
 .. _dpab_on: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
-.. |warmboot| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING``
-.. _warmboot: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+.. |dpab_on_pdf| replace:: PDF
+.. _dpab_on_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
+
+.. |dpab_on_doc| replace:: DOC
+.. _dpab_on_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.doc
 
 .. |standby| replace:: ``SOP_61021_STANDBY``
 .. _standby: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61021_STANDBY.pdf
+
+.. |standby_pdf| replace:: PDF
+.. _standby_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61021_STANDBY.pdf
+
+.. |standby_doc| replace:: DOC
+.. _standby_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_61021_STANDBY.doc
+
+.. |warmboot| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING``
+.. _warmboot: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+
+.. |warmboot_pdf| replace:: PDF
+.. _warmboot_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+
+.. |warmboot_doc| replace:: DOC
+.. _warmboot_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.doc
+
+.. |cap1055_pdf| replace:: PDF
+.. _cap1055_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf
 
 SOT Procedures
 ++++++++++++++
@@ -125,11 +146,11 @@ SOT Procedures
 FOT Procedures
 ++++++++++++++
 
-* |dpab_on|_
-* |standby|_
-* |warmboot|_
+* ``SOP_ACIS_DPAB_ON`` (|dpab_on_pdf|_) (|dpab_on_doc|_)
+* ``SOP_61021_STANDBY`` (|standby_pdf|_) (|standby_doc|_)
+* ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING`` (|warmboot_pdf|_) (|warmboot_doc|_)
 
 CAPs
 ++++
 
-* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
+* CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) (|cap1055_pdf|_)

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -1,0 +1,110 @@
+.. _dpab-shutdown:
+
+DPA-B Anomalous Shutdown
+========================
+
+What is it?
+-----------
+
+The DPA-B shuts down anomalously, presumably due to a spurious command.
+
+When did it happen before?
+--------------------------
+
+The DPA-B has shut down once:  
+
+* December 13, 2007: 2007:347:17:50, obsid 58072
+
+Will it happen again?
+---------------------
+
+It appears likely that the anomaly will occur again if the mission continues.
+
+How is this Anomaly Diagnosed?
+------------------------------
+
+Within a major frame (32.2 seconds), one should see:
+
+* 1DPPSB (DPA-B Power Supply On/Off) change from 1 to 0
+* 1DPP0BV0 (DPA-B +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPICBCU (DPA-B Input Current) drop to < 0.2 A (this value is noisy, so take an average)
+* DPA-B POWER should go to zero
+* 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
+  the load suddenly dropping to zero
+
+All other hardware telemetry should be nominal. The current values for these can be found
+on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
+engineering archive.
+
+What is the first response?
+---------------------------
+
+Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
+
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Call the Flight Directors:   
+
+  - Call the lead Flight Director, Tom Aldcroft. Leave a message if he does not answer.
+  - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
+
+* Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
+  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
+  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+* Convene a telecon at the next reasonable moment.
+* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
+  Engineer to request it.
+* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
+  the focal plane temperature. 
+* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
+  to be stopped, and the FEPs and video boards maybe need to be powered down.
+
+Impacts
+-------
+
+* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
+  needs to be powered back on science operations may need to be temporarily stopped.
+* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
+  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
+* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
+  than expected input current) due to FEPs being off. This situation should resolve itself with 
+  the next observation.
+
+
+Relevant Procedures
+-------------------
+
+.. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
+.. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
+
+.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
+.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
+
+.. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
+.. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+
+SOT Procedures
+++++++++++++++
+
+* `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
+* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
+* `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
+
+FOT Procedures
+++++++++++++++
+
+* |dpab_on|_
+* |stdfoptg|_
+* |fptemp_121|_
+
+CAPs
+++++
+
+* `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
+
+Relevant Notes/Memos
+--------------------
+
+* `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
+* `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -25,7 +25,7 @@ How is this Anomaly Diagnosed?
 
 Within a major frame (32.2 seconds), one should see:
 
-* 1DPPSB (DPA-B Power Supply On/Off) change from 1 to 0
+* 1DPPSB (DPA-B Power Supply On/Off) change from 1 to 0 (On to Off)
 * 1DPP0BV0 (DPA-B +5V Analog Voltage) drop to 0.0 +/- 0.3 V
 * 1DPICBCU (DPA-B Input Current) drop to < 0.2 A (this value is noisy, so take an average)
 * DPA-B POWER should go to zero

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -31,7 +31,7 @@ Within a major frame (32.2 seconds), one should see:
 * DPA-B POWER should go to zero
 * 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
-* If the DPA-B shutdown causes a watchdog reboot of the BEP, then 1STAT2ST = 0. 
+* If 1STAT2ST = 0, the DPA-B shutdown has caused a watchdog reboot of the BEP.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -26,7 +26,7 @@ How is this anomaly diagnosed?
 Within a major frame (32.2 seconds), one should see:
 
 * 1DPPSB (DPA-B Power Supply On/Off) change from 1 to 0 (On to Off)
-* 1DPP0BV0 (DPA-B +5V Analog Voltage) drop to 0.0 +/- 0.3 V
+* 1DPP0BVO (DPA-B +5V Analog Voltage) drop to 0.0 +/- 0.3 V
 * 1DPICBCU (DPA-B Input Current) drop to < 0.2 A (this value is noisy, so take an average)
 * DPA-B POWER should go to zero
 * 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
@@ -46,8 +46,8 @@ What is the response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_red_alert`` explaining the status of ACIS and state that the ACIS team
-  is investigating.
+* Send an email to ``sot_red_alert`` announcing a telecon to brief the FOT, SOT, and FDs on
+  the diagnosis and the plan to develop a CAP to recover.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
   email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
@@ -56,23 +56,25 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Once analysis of the dump data is complete, convene a telecon at the next reasonable moment
   with the ACIS team and review the diagnosis. The MIT ACIS team (Peter Ford, Bob Goeke, Mark
   Bautz, and Bev LaMarr) should also be included in the discussion, either in the telecon or
-  via email. If the diagnosis is consistent with previous DPA-A anomalies, proceed with the
-  recovery. If the diagnosis is not consistentwith previous DPA-A anomalies, stop and start a
+  via email. If the diagnosis is consistent with previous DPA-B anomalies, proceed with the
+  recovery. If the diagnosis is not consistent with previous DPA-B anomalies, stop and start a
   more involved analysis with the ACIS team.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
   a CAP to recover.
-* Prepare a CAP and submit it for review. The steps in the CAP will depend on whether or not the
-  active BEP has executed a watchdog reboot. This may happen if the shutdown occurs during an
-  observation that utilitizes the side B FEPs (side B powers FEPs 3-5), or if a subsequent 
-  observation requests them. Note that this implies that a watchdog reboot of the BEP will be 
-  avoided only if it occurs during an observation using only 1 or 2 CCDs, and until an 
-  observation occurs using 3 or more CCDs.
+* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu. It will also
+  be necessary to call the OC/CC to determine which number should be used for the CAP. The steps
+  in the CAP will depend on whether or not the active BEP has executed a watchdog reboot. This
+  may happen if the shutdown occurs during an observation that utilitizes the side B FEPs (side B
+  powers FEPs 3-5), or if a subsequent observation requests them. Note that this implies that a
+  watchdog reboot of the BEP will be avoided only if it occurs during an observation using only
+  1 or 2 CCDs, and until an observation occurs using 3 or more CCDs.
 
   1. If the BEP has not executed a watchdog reboot, the steps should be:
 
-     - Turn on DPA side B (|dpab_on|_)
+     - Turn on DPA side B (|dpab_on|_, this can be executed even if a science run is currently in
+       progress, see note below).
 
   2. If the BEP has executed a watchdog reboot, the steps should be:
 
@@ -116,7 +118,7 @@ SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
-* `Put ACIS Into Thermal Standby Mode <http://cxc.cfa.harvard.edu/acis/cmd_seq/standby.ps>`_
+* `Put ACIS Into Thermal Standby Mode <http://cxc.cfa.harvard.edu/acis/cmd_seq/standby.pdf>`_
 * `Warm Boot the Active ACIS BEP and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/warmboot_hkp.pdf>`_
 
 FOT Procedures

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -136,6 +136,9 @@ Relevant Procedures
 .. |cap1055_pdf| replace:: PDF
 .. _cap1055_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf
 
+.. |cap1055_doc| replace:: DOC
+.. _cap1055_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_Turn_on_DPA-B.doc
+
 SOT Procedures
 ++++++++++++++
 
@@ -153,4 +156,4 @@ FOT Procedures
 CAPs
 ++++
 
-* CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) (|cap1055_pdf|_)
+* CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) (|cap1055_pdf|_) (|cap1055_doc|_)

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -45,11 +45,12 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_red_alert`` announcing a telecon to brief the FOT, SOT, and FDs on
-  the diagnosis and the plan to develop a CAP to recover.
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr). If
+  it is off-hours, call Peter and Bob.
+* Send an email to ``sot_red_alert`` announcing that the ACIS team is aware of the DPA-B shutdown
+  and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
-  email or call when the dump file is available.
+  email or call us when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the single previous 
   occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
@@ -61,15 +62,15 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   more involved analysis with the ACIS team.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
-* Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
-  a CAP to recover.
-* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu. It will also
-  be necessary to call the OC/CC to determine which number should be used for the CAP. The steps
-  in the CAP will depend on whether or not the active BEP has executed a watchdog reboot. This
-  may happen if the shutdown occurs during an observation that utilitizes the side B FEPs (side B
-  powers FEPs 3-5), or if a subsequent observation requests them. Note that this implies that a
-  watchdog reboot of the BEP will be avoided only if it occurs during an observation using only
-  1 or 2 CCDs, and until an observation occurs using 3 or more CCDs.
+* Send an email to ``sot_red_alert`` and call a telecon with the FOT, SOT, and FDs to brief
+  them on the diagnosis and the plan to develop a CAP to recover.
+* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu, and cc: acisdude.
+  It will also be necessary to call the OC/CC to determine which number should be used for the CAP.
+  The steps in the CAP will depend on whether or not the active BEP has executed a watchdog reboot.
+  This may happen if the shutdown occurs during an observation that utilitizes the side B FEPs
+  (side B powers FEPs 3-5), or if a subsequent observation requests them. Note that this implies
+  that a watchdog reboot of the BEP will be avoided only if it occurs during an observation using
+  only 1 or 2 CCDs, and until an observation occurs using 3 or more CCDs.
 
   1. If the BEP has not executed a watchdog reboot, the steps should be:
 

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -58,8 +58,8 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   Engineer to request it.
 * Prepare a CAP to power back on the DPA-B and submit it for review. This CAP should also put ACIS
   into "thermal standby mode" before executing. If the shutdown occurs during an observation that 
-  utilitizes the side B FEPs, the active BEP may execut a watchdog reboot and it may be necessary 
-  to warm boot the BEP. 
+  utilitizes the side B FEPs, or if a subsequent observation requests them, the active BEP may 
+  execute a watchdog reboot and it may be necessary to warm boot the BEP. 
 * Execute the CAP at the next available comm.
 
 Impacts

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -31,7 +31,10 @@ Within a major frame (32.2 seconds), one should see:
 * DPA-B POWER should go to zero
 * 1DP28BVO (DPA-B +28V Input Voltage) is expected to have a small uptick, ~0.5 V, consistent with
   the load suddenly dropping to zero
-* If 1STAT2ST = 0, the DPA-B shutdown has caused a watchdog reboot of the BEP.
+* If 1STAT2ST = 0, the DPA-B shutdown has caused a watchdog reboot of the BEP in use. This will
+  happen if the DPA-B shuts down during an observation which is using B-side FEPs, or if the DPA-B
+  shuts down during an observation which is not using B-side FEPs but a subsequent observation does
+  use them.
 
 All other hardware telemetry should be nominal. The current values for these can be found
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -54,8 +54,7 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
 * Convene a telecon at the next reasonable moment.
 * As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
-* Identify whether or not additional comm time is needed and if so ask the Lead Systems 
-  Engineer to request it.
+* Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Prepare a CAP to power back on the DPA-B and submit it for review. This CAP should also put ACIS
   into "thermal standby mode" before executing. If the shutdown occurs during an observation that 
   utilitizes the side B FEPs, or if a subsequent observation requests them, the active BEP may 

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -72,12 +72,15 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
      - Turn on DPA side B (|dpab_on|_)
      - Warm-boot the BEP and start a DEA housekeeping run (|warmboot|_).
 
-  At this point in the mission (Jan 2017), it is standard practice to power off unused FEPs to
-  reduce power consumption and keep the electronics temperatures lower. For this reason, it is
-  believed that it is safe to power on the DPA side B during a science run that does not use
-  these FEPs. If this practice is changed later in the mission, this procedure may have to be
-  revisited.
 * Execute the CAP at the next available comm.
+
+.. note::
+
+   At this point in the mission (Jan 2017), it is standard practice to power off unused FEPs to
+   reduce power consumption and keep the electronics temperatures lower. For this reason, it is
+   believed that it is safe to power on the DPA side B during a science run that does not use
+   these FEPs. If this practice is changed later in the mission, this procedure may have to be
+   revisited.
 
 Impacts
 -------

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -46,14 +46,23 @@ What is the first response?
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
 * Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
-* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and the planned response.
+* Send an email to ``sot_yellow_alert`` explaining the status of ACIS and that the ACIS team is
+  investigating.
 * Call the Flight Directors, Tom Aldcroft and Scott Wolk. Leave messages if they do not answer.
+* Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to
+  email or call when the dump file is available.
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
   the shutdown. We want to know if a new occurrence looks just like the single previous 
   occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
-* Convene a telecon at the next reasonable moment.
-* As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
+* Once analysis of the dump data is complete, convene a telecon at the next reasonable moment
+  with the ACIS team and Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr, and review the
+  diagnosis. If the diagnosis is consistent with previous DPA-B anomalies, proceed with the
+  recovery. If the diagnosis is not consistentwith previous DPA-B anomalies, stop and start a
+  more involved analysis with the ACIS team.
+* As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
+* Call a telecon with the FOT, SOT, and FDs to brief them on the diagnosis and the plan to develop
+  a CAP to recover.
 * Prepare a CAP and submit it for review. The steps in the CAP will depend on whether or not the
   active BEP has executed a watchdog reboot. This may happen if the shutdown occurs during an
   observation that utilitizes the side B FEPs (side B powers FEPs 3-5), or if a subsequent 
@@ -72,6 +81,8 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
      - Warm-boot the BEP and start a DEA housekeeping run (|warmboot|_).
 
 * Execute the CAP at the next available comm.
+* Write a shift report and distribute to ``sot_shift`` to inform the project that ACIS is restored
+  to its default configuration.
 
 .. note::
 

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -48,8 +48,8 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr). If
-  it is off-hours, call Peter and Bob.
+* Send an email to the ACIS team at the official anomaly email address. If it is off-hours, call
+  Peter and Bob.
 * Send an email to ``sot_red_alert`` announcing that the ACIS team is aware of the DPA-B shutdown
   and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -56,7 +56,10 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
 * Identify whether or not additional comm time is needed and if so ask the OC/LSE to request it.
 * Prepare a CAP and submit it for review. The steps in the CAP will depend on whether or not the
   active BEP has executed a watchdog reboot. This may happen if the shutdown occurs during an
-  observation that utilitizes the side B FEPs, or if a subsequent observation requests them.
+  observation that utilitizes the side B FEPs (side B powers FEPs 3-5), or if a subsequent 
+  observation requests them. Note that this implies that a watchdog reboot of the BEP will be 
+  avoided only if it occurs during an observation using only 1 or 2 CCDs, and until an 
+  observation occurs using 3 or more CCDs.
 
   1. If the BEP has not executed a watchdog reboot, the steps should be:
 

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -49,28 +49,24 @@ Our real-time web pages will alert us and the Lead System Engineer will call us.
   - If Tom does not answer, call Scott Wolk. Leave a message if he does not answer.
 
 * Process the dump data and make sure that there is nothing anomalous in the data *BEFORE*
-  the shutdown. We want to know if a new occurrence looks just like the previous occurrences.
-  If yes, it should appear as if in one frame the DPA-A (or DPA-B) turned off.
+  the shutdown. We want to know if a new occurrence looks just like the single previous 
+  occurrence. If yes, it should appear as if in one frame the DPA-B turned off.
 * Convene a telecon at the next reasonable moment.
-* As soon as the time of the DPA-[AB] shutdown is known, inform ``sot_yellow_alert``. 
+* As soon as the time of the DPA-B shutdown is known, inform ``sot_yellow_alert``. 
 * Identify whether or not additional comm time is needed and if so ask the Lead Systems 
   Engineer to request it.
-* DPA-A shutdowns require reloading the patches, restarting DEA housekeeping, and resetting 
-  the focal plane temperature. 
-* DPA-B shutdowns require that the DPA-B be powered back on, science operations may need
-  to be stopped, and the FEPs and video boards maybe need to be powered down.
+* Prepare a CAP to power back on the DPA-B and bring it up for review. If the shutdown occurs during 
+  an observation that utilitizes the side B FEPs, the active BEP may execut a watchdog reboot and
+  it may be necessary to warm boot the BEP. (**also standby mode?**)
+* Execute the CAP at the next available comm.
 
 Impacts
 -------
 
-* Until the DPA-A is powered back on, science operations will be interrupted, but if DPA-B 
-  needs to be powered back on science operations may need to be temporarily stopped.
-* In the case of a side A or B shutdown, the warmboot of the BEP will reset the parameters of the 
-  TXINGS patch to their defaults. They can be updated in the weekly load through a SAR.
-* After recovery from a DPA-A shutdown, the power status may be in an unusual state (e.g., lower
-  than expected input current) due to FEPs being off. This situation should resolve itself with 
-  the next observation.
-
+* Until the DPA-B is powered back on, science operations which require the use of the side B FEPs
+  will be interrupted.
+* If it is necessary to warm boot the BEP, this will reset the parameters of the TXINGS patch 
+  to their defaults. They can be updated in the weekly load through a SAR.
 
 Relevant Procedures
 -------------------
@@ -78,33 +74,22 @@ Relevant Procedures
 .. |dpab_on| replace:: ``SOP_ACIS_DPAB_ON``
 .. _dpab_on: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DPAB_ON.pdf
 
-.. |stdfoptg| replace:: ``SOP_ACIS_SW_STDFOPTG``
-.. _stdfoptg: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_SW_STDFOPTG.pdf
-
-.. |fptemp_121| replace:: ``SOT_SI_SET_ACIS_FP_TEMP_TO_M121C``
-.. _fptemp_121: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_SI_SET_ACIS_FP_TEMP_TO_M121C.pdf
+.. |warmboot| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING``
+.. _warmboot: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
 
 SOT Procedures
 ++++++++++++++
 
 * `Turn On DPA-B <http://cxc.cfa.harvard.edu/acis/cmd_seq/dpab_on.pdf>`_
-* `Flight Software Standard Patch F, Optional Patch G <http://cxc.cfa.harvard.edu/acis/cmd_seq/sw_stdfoptg.pdf>`_
-* `Set Focal Plane Temperature to -121 C <http://cxc.cfa.harvard.edu/acis/cmd_seq/setfp_m121.pdf>`_
+* `Warm Boot the Active ACIS BEP and Start DEA Housekeeping Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/warmboot_hkp.pdf>`_
 
 FOT Procedures
 ++++++++++++++
 
 * |dpab_on|_
-* |stdfoptg|_
-* |fptemp_121|_
+* |warmboot|_
 
 CAPs
 ++++
 
 * `CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1001_1100/CAP_1055_Turn_on_DPA_B/CAP_1055_CMDing_Turn_On_DPA_B_warmboot_BEP_A_sign.pdf>`_
-
-Relevant Notes/Memos
---------------------
-
-* `Flight Note 394 <http://cxc.cfa.harvard.edu/acis/memos/FN394.ps>`_
-* `Flight Note 417 <http://cxc.cfa.harvard.edu/acis/memos/FN417.ps>`_

--- a/source/index.rst
+++ b/source/index.rst
@@ -16,7 +16,8 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
-   dpa_shutdown
+   dpaa_shutdown
+   dpab_shutdown
    dea_shutdown
    dea_seq_reset
    fep_reset


### PR DESCRIPTION
This PR modifies the DPA shutdown page, firstly by splitting it into two, one for DPA-A and another for DPA-B.

The rest of the edits are comprised of adding procedures and scripts that may or may not be used in such an event, and adding in extra steps that need to be taken in response.

These edits were prompted by the anomalous DPA-A shutdown of 2016:344.