### PR TITLE
Stuck status bit anomaly page

### DIFF
--- a/source/fep_thresholder.rst
+++ b/source/fep_thresholder.rst
@@ -1,4 +1,4 @@
-.. _hi-lo-anomaly:
+.. _fep-thresholder:
 
 FEP Thresholder Anomaly
 =======================

--- a/source/index.rst
+++ b/source/index.rst
@@ -21,6 +21,6 @@ Contents:
 * :doc:`hi_lo_anomaly` (Last Updated June 28, 2017)
 * :doc:`trickle_bias_tplane` (Last Updated November 18, 2016)
 * :doc:`fep_thresholder` (Last updated August 14, 2017)
-* :doc:`stuck_status_bit` (Last updated October 19, 2017)
+* :doc:`stuck_status_bit` (Last updated October 30, 2017)
 
 :doc:`howto`

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,10 +6,10 @@
 ACIS Anomaly Documentation
 ==========================
 
-These pages detail possible ACIS-related anomalies that may occur. Each page describes 
-the anomaly itself, when it has happened in the past, how likely it is to happen again, 
-and what the response should be. Appropriate links are also given to relevant flight 
-notes, procedures, and other documentation.
+These pages detail possible ACIS-related anomalies that may occur. Each page 
+describes the anomaly itself, when it has happened in the past, how likely it is
+to happen again, and what the response should be. Appropriate links are also 
+given to relevant flight notes, procedures, and other documentation.
 
 Contents:
  
@@ -21,5 +21,6 @@ Contents:
 * :doc:`hi_lo_anomaly` (Last Updated June 28, 2017)
 * :doc:`trickle_bias_tplane` (Last Updated November 18, 2016)
 * :doc:`fep_thresholder` (Last updated August 14, 2017)
+* :doc:`stuck_status_bit` (Last updated October 19, 2017)
 
 :doc:`howto`

--- a/source/stuck_status_bit.rst
+++ b/source/stuck_status_bit.rst
@@ -34,6 +34,7 @@ How is this anomaly diagnosed?
 * All other indicators (ACIS voltages, input currents, power, temperatures, and
   SIM position) should indicate that the equipment has shut down as normal for 
   an SCS-107 run, so the instrument is safe.  Since SCS-107 issues a WSPOW00000 command that powers down the video boards and the FEPs, the input currents on the DPA side A and B should be:
+  
   - DPA side A, 1DPICACU < 0.6 A
   - DPA side B, 1DPICBCU < 0.4 A
 

--- a/source/stuck_status_bit.rst
+++ b/source/stuck_status_bit.rst
@@ -1,0 +1,149 @@
+.. _stuck_status_bit:
+
+ACIS Science Run Termination Failure Anomaly
+============================================
+
+What is it?
+-----------
+
+SCS107 command fails to terminate a science run during bias creation.
+
+When did it happen before?
+--------------------------
+
+Twice:
+
+* March 3, 2016: 2016:063:17:11, obsid 17719
+* September 11, 2017:256:07:53, obsid 19931
+
+Will it happen again?
+---------------------
+
+It appears likely that the anomaly could occur again.
+
+How is this Anomaly Diagnosed?
+------------------------------
+
+* During a safe-mode transition, the 1STAT1ST ACIS status bit fails to set as 
+  expected, from Science Active (0 or RED) to Science Idle (1 or GREEN). The 
+  ACIS status bits are available on both the ACIS PMON web pages and the 
+  hardware web pages.
+
+* This is indicates that the science process failed to terminate and exit when 
+  SCS-107 was run.
+
+* All other indicators (ACIS voltages, input currents, power, temperatures, and
+  SIM position) should indicate that the equipment has shut down as normal for 
+  an SCS-107 run, so the instrument is safe.
+
+What is the first response?
+---------------------------
+
+The anomaly is most likely to be noted by ACIS ops during the first contact 
+after a safe mode transition.  It does not produce any automated alerts.
+
+We need to:
+ 
+* Send an e-mail to the ACIS team (including acisdude, Peter Ford, Bob Goeke,
+  Mark Bautz, and Bev LaMarr) to alert them to the existence of the anomaly.
+* Send a notification to the Flight Directors including the time of the anomaly
+  and the Obsid when it occurred.  Paul Viens?  telecon briefing?
+* Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu,
+  and cc: acisdude. It will also be necessary to call the OC/CC to determine 
+  which number should be used for the CAP.
+
+  This CAP will have the following steps:
+
+  - Confirm telemetry format is 1 or 2 and the most recent version of flight SW 
+    is running
+  - Warmboot the BEP and restart DEA housekeeping (|wmboot_hk|_)
+
+  There is a template CAP in acis_docs: CAPXXXX_WMBOOT_HK
+
+* Execute the CAP at the next available comm.
+* Write a shift report and distribute to ``sot_shift`` to inform the project 
+  that ACIS is restored to its default configuration.
+
+Impacts
+-------
+
+* The anomaly occurs during safe mode transition, so no science is lost.
+* The warmboot of the BEP will reset the parameters of the TXINGS patch to their
+  defaults.  They can be updated in the weekly load through a SAR.
+* If a science run is started before a warmboot can be performed, testing on the 
+  ACIS Engineering Unit has shown that the initiation of the run will clear the 
+  problem, but not without generating an error message due to "clobbering" the 
+  hung process.
+
+.. note::
+
+    As of this writing, the latest ACIS Flight Software Patch is F, Optional 
+    Patch G. An update has been developed to the ``buscrash`` patch which would
+    prevent this anomaly, but has not been deemed critical enough to drive a 
+    flight software update at this time.
+
+Relevant Procedures
+-------------------
+
+.. |wmboot_hk| replace:: ``SOP_ACIS_WARMBOOT_DEAHOUSKEEPING``
+.. _wmboot_hk: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+
+.. |wmboot_hk_pdf| replace:: PDF
+.. _wmboot_hk_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.pdf
+
+.. |wmboot_hk_doc| replace:: DOC
+.. _wmboot_hk_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING.doc
+
+.. |wmboot_hk_ssc| replace:: ``I_1_WARMBOOT.ssc``
+.. _wmboot_hk_ssc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/products/ssc/I_1_WARMBOOT.ssc
+
+.. |deahk_load_cld| replace:: ``IA_WD000_137.CLD``
+.. _deahk_load_cld: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_WD000_137.CLD
+
+.. |deahk_start_cld| replace:: ``IA_XD000_185.CLD``
+.. _deahk_start_cld: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/archive/cld/1A_XD000_185.CLD
+
+SOT Procedures
+++++++++++++++
+
+* `Warm Boot the Active ACIS BEP and Start DEA HK Run <http://cxc.cfa.harvard.edu/acis/cmd_seq/warmboot_hkp.pdf>`_
+
+FOT Procedures
+++++++++++++++
+
+* ``SOP_ACIS_WARMBOOT_DEAHOUSEKEEPING`` (|wmboot_hk_pdf|_) (|wmboot_hk_doc|_)
+
+FOT Scripts
++++++++++++
+
+* |wmboot_hk_ssc|_
+
+CLD Scripts
++++++++++++
+
+* |deahk_load_cld|_
+* |deahk_start_cld|_
+
+CAPs
+++++
+
+.. |cap1381_pdf| replace:: PDF
+.. _cap1381_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1381_wmboot_deahk/CAP_1381_wmboot_deahk.pdf
+
+.. |cap1381_doc| replace:: DOC
+.. _cap1381_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1381_wmboot_deahk/CAP_1381_wmboot_deahk.doc
+
+.. |cap1433_pdf| replace:: PDF
+.. _cap1433_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1433__wmboot_deahk/CAP1433__wmboot_deahk.pdf
+
+.. |cap1433_doc| replace:: DOC
+.. _cap1433_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1433__wmboot_deahk/CAP1433__wmboot_deahk.doc
+
+* CAP 1433 (ACIS BEP Warmboot and DEA housekeeping restart) (|cap1433_pdf|_) (|cap1433_doc|_)
+* CAP 1381 (ACIS BEP Warmboot and DEA housekeeping restart) (|cap1381_pdf|_) (|cap1381_doc|_)
+
+Relevant Notes/Memos
+--------------------
+
+* `ACIS-MIT Software Problem Report 151 <http://acis.mit.edu/axaf/spr/prob0151.html>`_
+* `Flight Note 574 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note574_Sci_Run_Termination_Failure_Closeout.pdf>`_

--- a/source/stuck_status_bit.rst
+++ b/source/stuck_status_bit.rst
@@ -58,7 +58,10 @@ We need to:
     is running
   - Warmboot the BEP and restart DEA housekeeping (|wmboot_hk|_)
 
-  There is a template CAP in acis_docs: CAPXXXX_WMBOOT_HK
+  There is a template CAP in ``acis_docs``: ``CAPXXXX_WMBOOT_HK``
+
+.. raw:: html
+    <br>
 
 * Execute the CAP at the next available comm.
 * Write a shift report and distribute to ``sot_shift`` to inform the project 

--- a/source/stuck_status_bit.rst
+++ b/source/stuck_status_bit.rst
@@ -6,59 +6,59 @@ ACIS Science Run Termination Failure Anomaly
 What is it?
 -----------
 
-SCS107 command fails to terminate a science run during bias creation.
+The science run fails to terminate when SCS-107 issues two stopScience commands during bias creation.
 
 When did it happen before?
 --------------------------
 
 Twice:
 
-* March 3, 2016: 2016:063:17:11, obsid 17719
-* September 11, 2017:256:07:53, obsid 19931
+* March 3, 2016, 2016:063:17:11, obsid 17719
+* September 11, 2017, 2017:256:07:53, obsid 19931
 
 Will it happen again?
 ---------------------
 
 It appears likely that the anomaly could occur again.
 
-How is this Anomaly Diagnosed?
+How is this anomaly diagnosed?
 ------------------------------
 
-* During a safe-mode transition, the 1STAT1ST ACIS status bit fails to set as 
+* After the execution of SCS-107, the 1STAT1ST ACIS status bit fails to set as 
   expected, from Science Active (0 or RED) to Science Idle (1 or GREEN). The 
-  ACIS status bits are available on both the ACIS PMON web pages and the 
-  hardware web pages.
+  ACIS status bits are available on both the ACIS hardware web pages and the PMON web pages where 1STAT1ST is the seventh digit in the Bilevels display.
 
-* This is indicates that the science process failed to terminate and exit when 
+* The 1STAT1ST status bit indicates that the science process failed to terminate and exit when 
   SCS-107 was run.
 
 * All other indicators (ACIS voltages, input currents, power, temperatures, and
   SIM position) should indicate that the equipment has shut down as normal for 
-  an SCS-107 run, so the instrument is safe.
+  an SCS-107 run, so the instrument is safe.  Since SCS-107 issues a WSPOW00000 command that powers down the video boards and the FEPs, the input currents on the DPA side A and B should be:
+  - DPA side A, 1DPICACU < 0.6 A
+  - DPA side B, 1DPICBCU < 0.4 A
 
 What is the first response?
 ---------------------------
 
 The anomaly is most likely to be noted by ACIS ops during the first contact 
-after a safe mode transition.  It does not produce any automated alerts.
+after an SCS-107 execution.  It does not produce any automated alerts.
 
 We need to:
  
 * Send an e-mail to the ACIS team (including acisdude, Peter Ford, Bob Goeke,
   Mark Bautz, and Bev LaMarr) to alert them to the existence of the anomaly.
-* Send a notification to the Flight Directors including the time of the anomaly
-  and the Obsid when it occurred.  Paul Viens?  telecon briefing?
+* Notify the Chandra Operations team on the telecon after the SCS-107 execution was discovered.  If not possible, send email to ``sot_yellow_alert`` describing the situation, including the time of the anomaly and the Obsid when it occured.
 * Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu,
   and cc: acisdude. It will also be necessary to call the OC/CC to determine 
   which number should be used for the CAP.
 
   This CAP will have the following steps:
 
-  - Confirm telemetry format is 1 or 2 and the most recent version of flight SW 
+  - Confirm telemetry format is 1 or 2 and the most recent version of flight software 
     is running
   - Warmboot the BEP and restart DEA housekeeping (|wmboot_hk|_)
 
-  There is a template CAP in ``acis_docs``: ``CAPXXXX_WMBOOT_HK``
+  There is a template CAP in ``acis_docs/CAPs``: ``CAPXXXX_WMBOOT_HK``
 
 .. raw:: html
     <br>
@@ -70,7 +70,7 @@ We need to:
 Impacts
 -------
 
-* The anomaly occurs during safe mode transition, so no science is lost.
+* The anomaly occurs after SCS-107 execution, so no science is lost.
 * The warmboot of the BEP will reset the parameters of the TXINGS patch to their
   defaults.  They can be updated in the weekly load through a SAR.
 * If a science run is started before a warmboot can be performed, testing on the 
@@ -81,7 +81,7 @@ Impacts
 .. note::
 
     As of this writing, the latest ACIS Flight Software Patch is F, Optional 
-    Patch G. An update has been developed to the ``buscrash`` patch which would
+    Patch G, Version 53. An update has been developed to the ``buscrash`` patch which would
     prevent this anomaly, but has not been deemed critical enough to drive a 
     flight software update at this time.
 
@@ -142,7 +142,7 @@ CAPs
 .. |cap1433_doc| replace:: DOC
 .. _cap1433_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1433__wmboot_deahk/CAP1433__wmboot_deahk.doc
 
-* CAP 1433 (ACIS BEP Warmboot and DEA housekeeping restart) (|cap1433_pdf|_) (|cap1433_doc|_)
+* CAP 1433 (ACIS BEP Warmboot and DEA housekeeping restart) (|cap1433_pdf|_) (|cap1433_doc|_)  (Note the double underscore before wmboot in the filename.)
 * CAP 1381 (ACIS BEP Warmboot and DEA housekeeping restart) (|cap1381_pdf|_) (|cap1381_doc|_)
 
 Relevant Notes/Memos


### PR DESCRIPTION
This PR implements the anomaly page for the stuck status bit anomaly, written by @cegrant.

A rendered version of the docs appears at http://cxc.cfa.harvard.edu/acis/stuck_status_bit/stuck_status_bit.html. 

I also fixed a couple of formatting issues I found elsewhere in the documentation. 

Note that @cegrant has a question about who to notify / if to have a telecon / etc in the current draft.