### PR TITLE
Add links to ACISpy and ACORN instructions

### DIFF
--- a/source/dea_seq_reset.rst
+++ b/source/dea_seq_reset.rst
@@ -50,12 +50,16 @@ may also be red ``SMRABORT`` messages, and/or a ``FEP_IO_ERROR`` message.
 2. Run ACORN on the file as per the instructions in
    `"Running ACORN on data dumps in the case of an anomaly (04/06/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Acorn.html>`_.
    This provides history of input currents 1DPIC[AB]CU and the status bit 1STAT1ST mentioned above.
-
+   
 3. Run the MIT decom on the data dump as per the instructions in
    `"Memo on Running MIT tools (04/26/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Psci.html>`_. 
    This will provide history of the FEP temperatures mentioned above.
 
-4. MIT personnel can look at the error code, if any, in the science report packet at the
+4. Information from the tracelog files written by the ACORN and/or MIT tools can
+   be plotted using the Python or command-line interfaces to ACISpy, see below
+   for details.
+   
+5. MIT personnel can look at the error code, if any, in the science report packet at the
    end of the run, and verify the error code mentioned above.
 
 
@@ -96,3 +100,13 @@ Access locked (very terse problem reports):
 Open access, full memo:
 
 * `ACIS-MIT Software Problem Report 136 <ftp://acis.mit.edu/pub/SPR136-1.0.pdf>`_
+
+.. |mptl| replace:: ``multiplot_tracelog`` Command-line Script
+.. _mptl: http://cxc.cfa.harvard.edu/acis/acispy/command_line.html#multiplot-tracelog
+
+Relevant ACISpy Links
+---------------------
+
+* `Reading MSID Data from Tracelog File <http://cxc.cfa.harvard.edu/acis/acispy/loading_data.html#reading-msid-data-from-a-tracelog-file>`_
+* `Plotting Data in Python <http://cxc.cfa.harvard.edu/acis/acispy/plotting_data.html>`_
+* |mptl|_

--- a/source/dea_shutdown.rst
+++ b/source/dea_shutdown.rst
@@ -39,8 +39,13 @@ Within a major frame (32.2 seconds), one should see:
   the load suddenly dropping to zero
 
 All other hardware telemetry should be nominal. The current values for these can be found 
-on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the 
-engineering archive.
+on our Real-Time Telemetry pages. Older data can be examined from the dump files or the 
+engineering archive. 
+
+To extract information from the dump data, run ACORN on it as per the instructions in
+`"Running ACORN on data dumps in the case of an anomaly (04/06/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Acorn.html>`_. 
+Information from the tracelog files written by the ACORN tools can be plotted 
+using the Python or command-line interfaces to ACISpy, see below for details.
 
 
 What is the first response?
@@ -171,3 +176,13 @@ Relevant Notes/Memos
   <http://cxc.cfa.harvard.edu/acis/memos/Flight_Note572_DEA_Shutdown_Closeout_merged.pdf>`_
   (includes SOT memo "ACIS DEA-A Off anomaly" by Edgar & Germain)
 * `ACIS - DEA ADC Reset (Dorothy Gordon) <http://cxc.cfa.harvard.edu/acis/memos/gordon_dea_20051118.pdf>`_
+
+.. |mptl| replace:: ``multiplot_tracelog`` Command-line Script
+.. _mptl: http://cxc.cfa.harvard.edu/acis/acispy/command_line.html#multiplot-tracelog
+
+Relevant ACISpy Links
+---------------------
+
+* `Reading MSID Data from Tracelog File <http://cxc.cfa.harvard.edu/acis/acispy/loading_data.html#reading-msid-data-from-a-tracelog-file>`_
+* `Plotting Data in Python <http://cxc.cfa.harvard.edu/acis/acispy/plotting_data.html>`_
+* |mptl|_

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -42,8 +42,14 @@ Within a major frame (32.2 seconds), one should see:
 * The software and hardware bilevels will likely not have normal values if BEP side A is active.
 
 All other hardware telemetry should be nominal. The current values for these can be found
-on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
+on our Real-Time Telemetry pages. Older data can be examined from the dump files or the
 engineering archive.
+
+To extract information from the dump data, run ACORN on it as per the instructions in
+`"Running ACORN on data dumps in the case of an anomaly (04/06/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Acorn.html>`_. 
+Information from the tracelog files written by the ACORN tools can be plotted 
+using the Python or command-line interfaces to ACISpy, see below for details.
+
 
 What is the response?
 ---------------------
@@ -187,3 +193,13 @@ Relevant Notes/Memos
 * `Flight Note 394 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note394_DPA_Turn_Off_Anomaly.pdf>`_
 * `Flight Note 417 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note417_DPA_Turn_Off_Anomaly.pdf>`_
 * `Flight Note 563 <https://occweb.cfa.harvard.edu/occweb/FOT/configuration/flightnotes/controlled/Flight_Note563_DPA-A_Turn_Off_Anomaly_Report.pdf>`_
+
+.. |mptl| replace:: ``multiplot_tracelog`` Command-line Script
+.. _mptl: http://cxc.cfa.harvard.edu/acis/acispy/command_line.html#multiplot-tracelog
+
+Relevant ACISpy Links
+---------------------
+
+* `Reading MSID Data from Tracelog File <http://cxc.cfa.harvard.edu/acis/acispy/loading_data.html#reading-msid-data-from-a-tracelog-file>`_
+* `Plotting Data in Python <http://cxc.cfa.harvard.edu/acis/acispy/plotting_data.html>`_
+* |mptl|_

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -43,6 +43,11 @@ All other hardware telemetry should be nominal. The current values for these can
 on our Real-Time Telemetry pages.  Older data can be examined from the dump files or the
 engineering archive.
 
+To extract information from the dump data, run ACORN on it as per the instructions in
+`"Running ACORN on data dumps in the case of an anomaly (04/06/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Acorn.html>`_. 
+Information from the tracelog files written by the ACORN tools can be plotted 
+using the Python or command-line interfaces to ACISpy, see below for details.
+
 What is the response?
 ---------------------
 
@@ -160,3 +165,13 @@ CAPs
 ++++
 
 * CAP 1055 (Commanding to Turn On DPA Side B and Warm Boot BEP Side A) (|cap1055_pdf|_) (|cap1055_doc|_)
+
+.. |mptl| replace:: ``multiplot_tracelog`` Command-line Script
+.. _mptl: http://cxc.cfa.harvard.edu/acis/acispy/command_line.html#multiplot-tracelog
+
+Relevant ACISpy Links
+---------------------
+
+* `Reading MSID Data from Tracelog File <http://cxc.cfa.harvard.edu/acis/acispy/loading_data.html#reading-msid-data-from-a-tracelog-file>`_
+* `Plotting Data in Python <http://cxc.cfa.harvard.edu/acis/acispy/plotting_data.html>`_
+* |mptl|_

--- a/source/fep_reset.rst
+++ b/source/fep_reset.rst
@@ -87,12 +87,15 @@ are watching then:
 
 To look at these values:
 
-
 3. When available, obtain the relevant dump data file from the directory:
 
    ``/dsops/critical/GOT/input/`` 
    
-   which is located on the Ops LAN, and extract the relevant MSIDs.
+   which is located on the Ops LAN, and extract the relevant MSIDs using
+   ACORN, as per the instructions in
+   `"Running ACORN on data dumps in the case of an anomaly (04/06/16)" <http://cxc.cfa.harvard.edu/acis/memos/Dump_Acorn.html>`_.
+   The MSID data in the tracelog can then be examined using ACISpy, see
+   the links below for details.
 
 4. There are a total of 8 boards in the DPA, powered independently:
 
@@ -169,3 +172,13 @@ Relevant Notes/Memos
 
 * Obsid 15232: `ACIS OBSID 15232 Anomaly (5/17/2013) <ftp://acis.mit.edu/pub/acis-obsid-15232-anom.pdf>`_
 * Obsid 7647: `3-FEP reset anomaly (7/11/2007) <http://cxc.cfa.harvard.edu/acis/memos/OCCcm08039_closeout.pdf>`_
+
+.. |mptl| replace:: ``multiplot_tracelog`` Command-line Script
+.. _mptl: http://cxc.cfa.harvard.edu/acis/acispy/command_line.html#multiplot-tracelog
+
+Relevant ACISpy Links
+---------------------
+
+* `Reading MSID Data from Tracelog File <http://cxc.cfa.harvard.edu/acis/acispy/loading_data.html#reading-msid-data-from-a-tracelog-file>`_
+* `Plotting Data in Python <http://cxc.cfa.harvard.edu/acis/acispy/plotting_data.html>`_
+* |mptl|_

--- a/source/fep_thresholder.rst
+++ b/source/fep_thresholder.rst
@@ -40,53 +40,72 @@ exposure after some point in the observation.
 
 These symptoms may be noticed:
 
-*  Every other frame will be missing for one CCD after some point in the observation.  The data before this point should contain all frames.  If the anomaly occurs in realtime COM, the exposure numbers on the impacted CCD will be red on the PMON page, indicating dropped frames. But this can happen for a number of reasons (ratty COM, telemetry saturation, and this anomaly).  The telemetry will probably not saturate for this anomaly, and reported event rates may look normal for the affected CCD.  In addition, only odd or even frame numbers will be reported for that CCD.
+* Every other frame will be missing for one CCD after some point in the 
+  observation. The data before this point should contain all frames. If the 
+  anomaly occurs in realtime COM, the exposure numbers on the impacted CCD 
+  will be red on the PMON page, indicating dropped frames. But this can happen
+  for a number of reasons (ratty COM, telemetry saturation, and this anomaly). 
+  The telemetry will probably not saturate for this anomaly, and reported event 
+  rates may look normal for the affected CCD.  In addition, only odd or even 
+  frame numbers will be reported for that CCD.
 
-* After the anomaly occurs, there may be a region of the CCD for which events had been reported but for which no additional events are reported.
+* After the anomaly occurs, there may be a region of the CCD for which events 
+  had been reported but for which no additional events are reported.
 
-* After the anomaly occurs, there may be events that are reported on consecutive (undropped) frames.  These events will have the same chipx,chipy values but the pulse heights will change slowly from frame to frame as the delta overclock values change.  The raw pulse heights for the event and the bias values are not changing, but the overclock values are changing from frame to frame.  This can lead to an event being reported at the same position on consecutive frames until the overclock values change such that the event grade changes to a grade that is not accepted.
+* After the anomaly occurs, there may be events that are reported on consecutive
+  (undropped) frames. These events will have the same chipx, chipy values but 
+  the pulse heights will change slowly from frame to frame as the delta 
+  overclock values change. The raw pulse heights for the event and the bias 
+  values are not changing, but the overclock values are changing from frame to 
+  frame. This can lead to an event being reported at the same position on 
+  consecutive frames until the overclock values change such that the event 
+  grade changes to a grade that is not accepted.
 
 What is the first response?
 ---------------------------
 
 We need to: 
 
-* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, and Bev LaMarr)
+* Send an email to the ACIS team (including Peter Ford, Bob Goeke, Mark Bautz, 
+  and Bev LaMarr)
 
 * Process the dump data and get access to the CXC products
 
 * Notify ``sot_yellow_alert`` and/or brief the 9am telecon
 
-* Convene a telecon at the next reasonable moment. This would include the ACIS team as above. Agreement by MIT via e-mail is a possible alternative.
+* Convene a telecon at the next reasonable moment. This would include the ACIS 
+  team as above. Agreement by MIT via e-mail is a possible alternative.
 
-* Examine data from the next observation, because the setup for the next observation will clear the problem.
+* Examine data from the next observation, because the setup for the next 
+  observation will clear the problem.
 
 .. |sop_diagnostics| replace:: ``SOP_ACIS_DEA_FEP_DIAGNOSTICS``
 .. _sop_diagnostics: http://occweb.cfa.harvard.edu/occweb/FOT/configuration/procedures/SOP/SOP_ACIS_DEA_FEP_DIAGNOSTICS.pdf
 
-In the somewhat unlikely event that this anomaly is
-noticed during an observation, and there is time either
-during the current comm or a following one (still on
-the same obsid), we have
+In the somewhat unlikely event that this anomaly is noticed during an 
+observation, and there is time either during the current comm or a following 
+one (still on the same obsid), we have
 `an SOP (DEA FEP Diagnostics SOP) <http://cxc.cfa.harvard.edu/acis/cmd_seq/dea_fep_diags.pdf>`_
 written to intervene if the observation with the anomaly is still in
 progress to dump diagnostic data.
 
-This procedure suspends the observation while the diagnostics are run, and then resumes
-all chip/FEP combinations except the problematic one. If the target is not on the
-affected chip, it may be advantageous to the user to skip the diagnostic procedure
-and finish the observation uninterrupted.
+This procedure suspends the observation while the diagnostics are run, and then
+resumes all chip/FEP combinations except the problematic one. If the target is 
+not on the affected chip, it may be advantageous to the user to skip the 
+diagnostic procedure and finish the observation uninterrupted.
 
 If it is decided to run the diagnostics procedure, do this:
 
-* Send an e-mail to ``sot_red_alert`` and convene a telecon giving the plan, and the need for quick action to get the SOP done before the end of the science run.
+* Send an e-mail to ``sot_red_alert`` and convene a telecon giving the plan, and
+the need for quick action to get the SOP done before the end of the science run.
 
 * Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu.
 
 Impacts
 -------
 
-* The last portion of the science run for that particular CCD/FEP combination will be compromised. The following science run should be unaffected.
+* The last portion of the science run for that particular CCD/FEP combination 
+  will be compromised. The following science run should be unaffected.
 
 Relevant Procedures
 -------------------

--- a/source/stuck_status_bit.rst
+++ b/source/stuck_status_bit.rst
@@ -6,7 +6,8 @@ ACIS Science Run Termination Failure Anomaly
 What is it?
 -----------
 
-The science run fails to terminate when SCS-107 issues two stopScience commands during bias creation.
+The science run fails to terminate when SCS-107 issues two stopScience 
+commands during bias creation.
 
 When did it happen before?
 --------------------------
@@ -26,14 +27,17 @@ How is this anomaly diagnosed?
 
 * After the execution of SCS-107, the 1STAT1ST ACIS status bit fails to set as 
   expected, from Science Active (0 or RED) to Science Idle (1 or GREEN). The 
-  ACIS status bits are available on both the ACIS hardware web pages and the PMON web pages where 1STAT1ST is the seventh digit in the Bilevels display.
+  ACIS status bits are available on both the ACIS hardware web pages and the 
+  PMON web pages where 1STAT1ST is the seventh digit in the Bilevels display.
 
-* The 1STAT1ST status bit indicates that the science process failed to terminate and exit when 
-  SCS-107 was run.
+* The 1STAT1ST status bit indicates that the science process failed to terminate 
+  and exit when SCS-107 was run.
 
 * All other indicators (ACIS voltages, input currents, power, temperatures, and
   SIM position) should indicate that the equipment has shut down as normal for 
-  an SCS-107 run, so the instrument is safe.  Since SCS-107 issues a WSPOW00000 command that powers down the video boards and the FEPs, the input currents on the DPA side A and B should be:
+  an SCS-107 run, so the instrument is safe. Since SCS-107 issues a WSPOW00000 
+  command that powers down the video boards and the FEPs, the input currents on 
+  the DPA side A and B should be:
   
   - DPA side A, 1DPICACU < 0.6 A
   - DPA side B, 1DPICBCU < 0.4 A
@@ -48,7 +52,9 @@ We need to:
  
 * Send an e-mail to the ACIS team (including acisdude, Peter Ford, Bob Goeke,
   Mark Bautz, and Bev LaMarr) to alert them to the existence of the anomaly.
-* Notify the Chandra Operations team on the telecon after the SCS-107 execution was discovered.  If not possible, send email to ``sot_yellow_alert`` describing the situation, including the time of the anomaly and the Obsid when it occured.
+* Notify the Chandra Operations team on the telecon after the SCS-107 execution 
+  was discovered. If not possible, send email to ``sot_yellow_alert`` describing 
+  the situation, including the time of the anomaly and the Obsid when it occured.
 * Prepare a CAP and submit it for review to capreview AT ipa DOT harvard DOT edu,
   and cc: acisdude. It will also be necessary to call the OC/CC to determine 
   which number should be used for the CAP.
@@ -73,7 +79,7 @@ Impacts
 
 * The anomaly occurs after SCS-107 execution, so no science is lost.
 * The warmboot of the BEP will reset the parameters of the TXINGS patch to their
-  defaults.  They can be updated in the weekly load through a SAR.
+  defaults. They can be updated in the weekly load through a SAR.
 * If a science run is started before a warmboot can be performed, testing on the 
   ACIS Engineering Unit has shown that the initiation of the run will clear the 
   problem, but not without generating an error message due to "clobbering" the 


### PR DESCRIPTION
We talked a few weeks ago about the need to add instructions to these pages for how to use ACISpy to look at tracelog data. I ran through the docs and added the appropriate links where it is necessary, as well as adding a link to the ACORN instructions in a few places. 

I also adjusted the whitespace on a number of pages to make them easier to read in an editor.

Rendered version of docs here:

http://cxc.cfa.harvard.edu/acis/tmp/add_acispy/