### PR TITLE
Door b enb

### DIFF
--- a/source/door_b_enb.rst
+++ b/source/door_b_enb.rst
@@ -146,10 +146,10 @@ CAPs
 ++++
 
 .. |cap1438_pdf| replace:: PDF
-.. _cap1438_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1438_dpaa_poweroff_recovery/CAP_1438_dpaa_poweroff_recovery.pdf
+.. _cap1438_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1438_ACIS_Mechanism_Disable/CAP_1438_ACIS_Mechanism_Disable.pdf
 
 .. |cap1438_doc| replace:: DOC
-.. _cap1438_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1301_1400/CAP_1438_dpaa_poweroff_recovery/CAP_1438_dpaa_poweroff_recovery.doc
+.. _cap1438_doc: https://occweb.cfa.harvard.edu/occweb/FOT/configuration/CAPs/1401-1500/CAP_1438_ACIS_Mechanism_Disable/CAP_1438_ACIS_Mechanism_Disable.doc
 
 .. |temp_cap1438_pdf| replace:: TEMP PDF
 .. _temp_cap1438_pdf: https://occweb.cfa.harvard.edu/occweb/FOT/operations/caps_in_process/CAP_1438_ACIS_Mechanism_Disable.pdf
@@ -157,7 +157,7 @@ CAPs
 .. |temp_cap1438_doc| replace:: TEMP DOC
 .. _temp_cap1438_doc: https://occweb.cfa.harvard.edu/occweb/FOT/operations/caps_in_process/CAP_1438_ACIS_Mechanism_Disable.doc
 
-* CAP 1438 (ACIS Mechanism Disable) (|temp_cap1438_pdf|_) (|temp_cap1438_doc|_) (link TBR: these are in the caps in process area)
+* CAP 1438 (ACIS Mechanism Disable) (|cap1438_pdf|_) (|cap1438_doc|_) (link TBR: these are in the caps in process area)
 
 Relevant Notes/Memos
 --------------------

--- a/source/dpaa_shutdown.rst
+++ b/source/dpaa_shutdown.rst
@@ -56,8 +56,9 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team at the official anomaly email address. If it is off-hours, call
-  Peter and Bob.
+* Send an email to the ACIS team at the official anomaly email address,
+  ``acis-anomaly -at- googlegroups -dot- com``. If it is off-hours,
+  another ACIS Ops team member should call Peter, Bob, Kari, and Jim Francis.
 * Send an email to ``sot_red_alert@head`` announcing that the ACIS team is aware of the DPA-A shutdown
   and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to

--- a/source/dpab_shutdown.rst
+++ b/source/dpab_shutdown.rst
@@ -53,8 +53,9 @@ What is the response?
 
 Our real-time web pages will alert us and the Lead System Engineer will call us. We need to:
 
-* Send an email to the ACIS team at the official anomaly email address. If it is off-hours, call
-  Peter and Bob.
+* Send an email to the ACIS team at the official anomaly email address,
+  ``acis-anomaly -at- googlegroups -dot- com``. If it is off-hours, 
+  another ACIS Ops team member should call Peter, Bob, Kari, and Jim Francis.
 * Send an email to ``sot_red_alert@head`` announcing that the ACIS team is aware of the DPA-B shutdown
   and is investigating, and that a telecon will be called when more information is available.
 * Contact the GOT Duty Officer to inform that we need the dump data as soon as possible and to


### PR DESCRIPTION
I've moved the link to the door mechanism enable CAP to point at the permanent OCC repository of CAPs. While here, I also committed changes to dpaa_off and dpab_off, adding the anomaly e-mail list address.